### PR TITLE
feat(terraform): grant workload SA BQ access to collections dataset

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -121,3 +121,23 @@ resource "google_project_iam_member" "terraform_admin_storage" {
   role    = "roles/storage.admin"
   member  = "serviceAccount:${local.terraform_admin_sa}"
 }
+
+# -----------------------------------------------------------------------------
+# Local BigQuery access for CollectionStorage (collections dataset in this project)
+# -----------------------------------------------------------------------------
+
+# Project-level: create BQ jobs (query/load/MERGE). BQ does not offer
+# dataset-scoped job creation, so this is project-wide by necessity.
+resource "google_project_iam_member" "workload_local_bq_job_user" {
+  project = var.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.workload.email}"
+}
+
+# Dataset-scoped: read/write rows in the collections dataset.
+resource "google_bigquery_dataset_iam_member" "workload_collections_editor" {
+  project    = var.project_id
+  dataset_id = google_bigquery_dataset.collections.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${google_service_account.workload.email}"
+}


### PR DESCRIPTION
## Summary

Grants the workload service account two new permissions needed to upsert into the `collections.user_collections` table (created in #46):

- `roles/bigquery.jobUser` on `bgg-predictive-models` — BQ only allows project-level job creation.
- `roles/bigquery.dataEditor` scoped to the `collections` dataset — matches the tight-scoping pattern used for [`workload_dw_raw_write`](https://github.com/phenrickson/bgg-predictive-models/blob/main/terraform/iam.tf#L64).

## Why

Before this work the workload SA only wrote BQ data back to the data warehouse project. The collection-storage design moves collection state into this project's `collections` dataset, so the SA needs local BQ write access for the first time.

## Test plan

- [ ] CI `terraform plan` comment shows exactly 2 resources to add, no drift elsewhere.
- [ ] Merge triggers `terraform apply`; resources created.
- [ ] After apply, PR 2 integration tests (to come) pass when authenticating as the workload SA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)