### PR TITLE
feat(terraform): grant workload SA readSessionUser on local project

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -141,3 +141,11 @@ resource "google_bigquery_dataset_iam_member" "workload_collections_editor" {
   role       = "roles/bigquery.dataEditor"
   member     = "serviceAccount:${google_service_account.workload.email}"
 }
+
+# Project-level: BigQuery Storage Read API sessions (used by `to_dataframe()`
+# when fetching query results). Required for reads, not just writes.
+resource "google_project_iam_member" "workload_local_bq_read_session" {
+  project = var.project_id
+  role    = "roles/bigquery.readSessionUser"
+  member  = "serviceAccount:${google_service_account.workload.email}"
+}


### PR DESCRIPTION
## Summary

Follow-up to #47 — adds the third BQ role the workload SA needs on its own project: `roles/bigquery.readSessionUser`.

## Why

`pandas.to_dataframe()` on BigQuery query results uses the BigQuery Storage Read API. That API requires `readSessionUser`. The workload SA has this role on the data warehouse project ([iam.tf:57-61](https://github.com/phenrickson/bgg-predictive-models/blob/main/terraform/iam.tf#L57-L61)) but I missed the local mirror when writing #47.

Verified live: after #47 merged, the MERGE-based write path works end-to-end, but `CollectionStorage.get_latest_collection` fails with `403: the user does not have 'bigquery.readsessions.create' permission for 'projects/bgg-predictive-models'`.

## Test plan

- [ ] CI plan shows 1 resource to add.
- [ ] After merge+apply, PR 2 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)