### PR TITLE
fix: collection storage robust to usernames with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.6.2] - 2026-05-26
+
+### Fixed
+
+- **Usernames with spaces (e.g. `Watch It Played`) now flow end-to-end.**
+  Previously `just load "Watch It Played"` failed at argparse because
+  `{{user}}` was interpolated unquoted in the justfile, and downstream
+  readers built filesystem paths from the raw username — fragile
+  against any unquoted shell expansion.
+
+### Added
+
+- **`slugify_username()`** in
+  `src/collection/collection_artifact_storage.py`: case-preserving,
+  collapses non-`[A-Za-z0-9._-]` runs to underscores. Identity for the
+  six existing users (`phenrickson`, `GOBBluth89`, `Gyges`,
+  `TomBrewstErr`, `VWValker`, `rahdo`) — so their on-disk and GCS
+  directories continue to resolve unchanged.
+  `CollectionArtifactStorage.base_dir` now uses the slug.
+- **`metadata.json` written automatically** by
+  `CollectionPipeline.run_full_pipeline` after `save_collection`, so
+  the slug → real-username mapping is recoverable from the artifact
+  tree itself.
+- **Backfilled `metadata.json`** for all seven existing user
+  directories.
+
+### Changed
+
+- **`reports/render.py:_list_users`** reads each user's `metadata.json`
+  to return the real BGG username; falls back to the directory name
+  when metadata is missing.
+- **`src/reports/collection_data.py`** (`_load_outcome`,
+  `_outcome_root`) and **`services/collections/register_model.py`**
+  slugify usernames when composing local artifact paths. Identity
+  transform for usernames already filesystem-safe.
+- **`justfile`**: every `{{user}}` interpolation is now quoted, so
+  recipes accept usernames with spaces (`just load "Watch It Played"`,
+  `just ship "Watch It Played"`, etc.). Path-building recipes
+  (`sync-artifacts`, `pull-artifacts`, `promote-all`, `users-sweep`)
+  derive the slug via `slugify_username()` so local + GCS paths agree
+  with the python layer.
+
+No production effect: the scoring Cloud Run service does not import
+`register_model.py`; the daily `build-collection-reports` and
+`run-collection-scoring` workflows resolve all six production users
+through the identity slug.
+
 ## [0.6.1] - 2026-05-07
 
 ### Added

--- a/justfile
+++ b/justfile
@@ -26,19 +26,19 @@ default:
 # loaded yet.
 load user=username:
     uv run python -m src.collection.load \
-        --username {{user}} --environment {{environment}}
+        --username "{{user}}" --environment {{environment}}
 
 # Persist canonical train/val/test splits for an outcome.
 split user=username outcome="own":
     uv run python -m src.collection.split \
-        --username {{user}} --environment {{environment}} --outcome {{outcome}} \
+        --username "{{user}}" --environment {{environment}} --outcome {{outcome}} \
         --local-root {{local_root}}
 
 # Train one candidate (named in config.collections.candidates) against
 # the latest canonical splits.
 train user=username outcome="own" candidate="logistic_row_norm" splits_version="":
     uv run python -m src.collection.train \
-        --username {{user}} --environment {{environment}} --outcome {{outcome}} \
+        --username "{{user}}" --environment {{environment}} --outcome {{outcome}} \
         --candidate {{candidate}} \
         --local-root {{local_root}} \
         $([ -n "{{splits_version}}" ] && echo "--splits-version {{splits_version}}")
@@ -56,7 +56,7 @@ train-all user=username outcome="own":
     for c in $candidates; do
         echo "--- $c ---"
         if ! uv run python -m src.collection.train \
-            --username {{user}} --environment {{environment}} --outcome {{outcome}} \
+            --username "{{user}}" --environment {{environment}} --outcome {{outcome}} \
             --candidate "$c" --local-root {{local_root}}; then
             failed+=("$c")
         fi
@@ -69,7 +69,7 @@ train-all user=username outcome="own":
 # Print or write a comparison table for an outcome.
 compare user=username outcome="own" out="" candidates="":
     uv run python -m src.collection.compare \
-        --username {{user}} --environment {{environment}} --outcome {{outcome}} \
+        --username "{{user}}" --environment {{environment}} --outcome {{outcome}} \
         --local-root {{local_root}} \
         $([ -n "{{out}}" ] && echo "--out {{out}}") \
         $([ -n "{{candidates}}" ] && echo "--candidates {{candidates}}")
@@ -79,7 +79,7 @@ compare user=username outcome="own" out="" candidates="":
 # finalize_through=2025 if you need a different cutoff.
 finalize user=username outcome="own" candidate="logistic_row_norm" version="latest" finalize_through="":
     uv run python -m src.collection.finalize \
-        --username {{user}} --environment {{environment}} --outcome {{outcome}} \
+        --username "{{user}}" --environment {{environment}} --outcome {{outcome}} \
         --candidate {{candidate}} \
         $([ "{{version}}" != "latest" ] && echo "--version {{version}}") \
         $([ -n "{{finalize_through}}" ] && echo "--finalize-through {{finalize_through}}") \
@@ -98,7 +98,7 @@ finalize-all user=username outcome="own" finalize_through="":
     for c in $candidates; do
         echo "--- $c ---"
         if ! uv run python -m src.collection.finalize \
-            --username {{user}} --environment {{environment}} --outcome {{outcome}} \
+            --username "{{user}}" --environment {{environment}} --outcome {{outcome}} \
             --candidate "$c" --local-root {{local_root}} \
             $([ -n "{{finalize_through}}" ] && echo "--finalize-through {{finalize_through}}"); then
             failed+=("$c")
@@ -114,13 +114,13 @@ finalize-all user=username outcome="own" finalize_through="":
 # finalized.pkl (run `finalize` first).
 promote user=username outcome="own" candidate="logistic_row_norm" version="latest" description="":
     uv run python -m services.collections.register_model \
-        --username {{user}} --environment {{environment}} --outcome {{outcome}} \
+        --username "{{user}}" --environment {{environment}} --outcome {{outcome}} \
         --candidate {{candidate}} --version {{version}} \
         --local-root {{local_root}} \
         --description "$([ -n "{{description}}" ] && echo "{{description}}" || echo "{{candidate}} for {{user}}/{{outcome}}")"
     @echo "Dispatching model report render for {{user}}/{{outcome}}"
-    gh workflow run build-model-reports.yml -f users={{user}} -f outcome={{outcome}} || \
-        echo "WARN: model-report dispatch failed (promote still succeeded); rerun manually: gh workflow run build-model-reports.yml -f users={{user}} -f outcome={{outcome}}"
+    gh workflow run build-model-reports.yml -f users="{{user}}" -f outcome={{outcome}} || \
+        echo "WARN: model-report dispatch failed (promote still succeeded); rerun manually: gh workflow run build-model-reports.yml -f users='{{user}}' -f outcome={{outcome}}"
 
 # Full pipeline for one user/outcome/candidate:
 # load → split → train → finalize → sync-artifacts → promote.
@@ -133,18 +133,18 @@ promote user=username outcome="own" candidate="logistic_row_norm" version="lates
 ship user=username outcome="own" candidate="logistic_row_norm":
     #!/usr/bin/env bash
     set -e
-    just load {{user}}
-    just split {{user}} {{outcome}}
-    just train {{user}} {{outcome}} {{candidate}}
-    just finalize {{user}} {{outcome}} {{candidate}}
-    just sync-artifacts {{user}}
-    just promote {{user}} {{outcome}} {{candidate}}
+    just load "{{user}}"
+    just split "{{user}}" {{outcome}}
+    just train "{{user}}" {{outcome}} {{candidate}}
+    just finalize "{{user}}" {{outcome}} {{candidate}}
+    just sync-artifacts "{{user}}"
+    just promote "{{user}}" {{outcome}} {{candidate}}
 
 # Register one candidate across multiple outcomes in one shot.
 #   just promote-many rahdo "own,ever_owned,rated" lgbm_row_norm
 promote-many user=username outcomes="own" candidate="logistic_row_norm" version="latest" description="":
     uv run python -m services.collections.register_all \
-        --username {{user}} --environment {{environment}} \
+        --username "{{user}}" --environment {{environment}} \
         --outcomes "{{outcomes}}" \
         --candidate {{candidate}} --version {{version}} \
         --local-root {{local_root}} \
@@ -167,14 +167,15 @@ promote-all outcome="own":
     deployed=0; skipped=0; failed=0; \
     while IFS= read -r u; do \
         [ -z "$u" ] && continue; \
-        path="{{local_root}}/$u/{{outcome}}/$cand"; \
+        slug=$(uv run python -c 'import sys; from src.collection.collection_artifact_storage import slugify_username; print(slugify_username(sys.argv[1]))' "$u"); \
+        path="{{local_root}}/$slug/{{outcome}}/$cand"; \
         if ! ls $path/v*/finalized.pkl 2>/dev/null | grep -q .; then \
             echo "skip $u: no finalized.pkl under $path"; \
             skipped=$((skipped + 1)); \
             continue; \
         fi; \
         echo "=== promote $u {{outcome}} $cand ==="; \
-        if just promote $u {{outcome}} $cand; then \
+        if just promote "$u" {{outcome}} $cand; then \
             deployed=$((deployed + 1)); \
         else \
             echo "FAIL: $u"; \
@@ -190,7 +191,7 @@ promote-all outcome="own":
 #   just verify rahdo own
 verify user=username outcome="":
     uv run python -m services.collections.verify_models \
-        --username {{user}} \
+        --username "{{user}}" \
         $([ -n "{{outcome}}" ] && echo "--outcome {{outcome}}")
 
 # End-to-end experiment cycle: split → train all → compare.
@@ -199,11 +200,11 @@ verify user=username outcome="":
 sweep user=username outcome="own":
     #!/usr/bin/env bash
     set -e
-    just split {{user}} {{outcome}}
+    just split "{{user}}" {{outcome}}
     set +e
-    just train-all {{user}} {{outcome}}
+    just train-all "{{user}}" {{outcome}}
     train_status=$?
-    just compare {{user}} {{outcome}}
+    just compare "{{user}}" {{outcome}}
     exit $train_status
 
 # Train all candidates and compare against the most recent existing split.
@@ -212,9 +213,9 @@ sweep user=username outcome="own":
 train-compare user=username outcome="own":
     #!/usr/bin/env bash
     set +e
-    just train-all {{user}} {{outcome}}
+    just train-all "{{user}}" {{outcome}}
     train_status=$?
-    just compare {{user}} {{outcome}}
+    just compare "{{user}}" {{outcome}}
     exit $train_status
 
 # Sweep across a list of users. Skips users who already have at least
@@ -226,13 +227,14 @@ users-sweep users outcome="own":
     shopt -s nullglob
     failed=()
     for u in {{users}}; do
-        candidate_dirs=({{local_root}}/{{environment}}/$u/{{outcome}}/*/v*)
+        slug=$(uv run python -c 'import sys; from src.collection.collection_artifact_storage import slugify_username; print(slugify_username(sys.argv[1]))' "$u")
+        candidate_dirs=({{local_root}}/$slug/{{outcome}}/*/v*)
         if [ ${#candidate_dirs[@]} -gt 0 ]; then
             echo "skip $u (already processed)"
             continue
         fi
         echo "===== $u ====="
-        if ! just sweep $u {{outcome}}; then
+        if ! just sweep "$u" {{outcome}}; then
             failed+=("$u")
         fi
     done
@@ -255,7 +257,7 @@ render user=username outcome="own" report="" candidate="":
     reports="$([ -n "{{report}}" ] && echo "{{report}}" || echo "predictions model")"
     for r in $reports; do
         uv run python -m reports.render --report "$r" \
-            --username {{user}} --outcome {{outcome}} \
+            --username "{{user}}" --outcome {{outcome}} \
             $([ -n "{{candidate}}" ] && echo "--candidate {{candidate}}")
     done
     uv run python -m reports.build_index
@@ -301,8 +303,9 @@ gcs_artifacts_root := "gs://bgg-predictive-models/" + environment + "/collection
 sync-artifacts user=username prune="":
     #!/usr/bin/env bash
     set -e
-    src="{{local_root}}/{{user}}"
-    dst="{{gcs_artifacts_root}}/{{user}}"
+    slug=$(uv run python -c 'import sys; from src.collection.collection_artifact_storage import slugify_username; print(slugify_username(sys.argv[1]))' "{{user}}")
+    src="{{local_root}}/$slug"
+    dst="{{gcs_artifacts_root}}/$slug"
     if [ ! -d "$src" ]; then
         echo "No local artifacts for user '{{user}}' at $src" >&2
         exit 1
@@ -322,7 +325,7 @@ sync-artifacts-all prune="":
     for user_dir in {{local_root}}/*/; do
         u=$(basename "$user_dir")
         echo "===== $u ====="
-        if ! just sync-artifacts "$u" {{prune}}; then
+        if ! just sync-artifacts "$u" "{{prune}}"; then
             failed+=("$u")
         fi
     done
@@ -340,8 +343,9 @@ sync-artifacts-all prune="":
 pull-artifacts user=username prune="":
     #!/usr/bin/env bash
     set -e
-    src="{{gcs_artifacts_root}}/{{user}}"
-    dst="{{local_root}}/{{user}}"
+    slug=$(uv run python -c 'import sys; from src.collection.collection_artifact_storage import slugify_username; print(slugify_username(sys.argv[1]))' "{{user}}")
+    src="{{gcs_artifacts_root}}/$slug"
+    dst="{{local_root}}/$slug"
     mkdir -p "$dst"
     echo "pulling $src -> $dst"
     if [ -n "{{prune}}" ]; then
@@ -363,7 +367,7 @@ pull-artifacts-all prune="":
     fi
     for u in $users; do
         echo "===== $u ====="
-        if ! just pull-artifacts "$u" {{prune}}; then
+        if ! just pull-artifacts "$u" "{{prune}}"; then
             failed+=("$u")
         fi
     done

--- a/reports/render.py
+++ b/reports/render.py
@@ -68,7 +68,15 @@ def _install_offline_stubs() -> None:
 
 
 def _list_users(source: str) -> list[str]:
-    """Discover users by listing the artifact root."""
+    """Discover users by listing the artifact root.
+
+    Directory names on disk are *slugified* (e.g. ``Watch_It_Played``); the
+    real BGG username may differ (``"Watch It Played"``) and is recorded in
+    each user's ``metadata.json``. Prefer that real username; fall back to
+    the directory name when metadata is missing (older artifacts).
+    """
+    import json
+
     if source == "local":
         source = "models/collections"
     if source.startswith("gs://"):
@@ -76,11 +84,36 @@ def _list_users(source: str) -> list[str]:
 
         fs = fsspec.filesystem("gs")
         prefix = source.rstrip("/").removeprefix("gs://")
-        return [Path(p).name for p in fs.ls(prefix) if fs.isdir(p)]
+        names: list[str] = []
+        for p in fs.ls(prefix):
+            if not fs.isdir(p):
+                continue
+            dir_name = Path(p).name
+            meta_path = f"{p.rstrip('/')}/metadata.json"
+            try:
+                with fs.open(meta_path) as f:
+                    real = json.load(f).get("username")
+                names.append(real or dir_name)
+            except (FileNotFoundError, OSError):
+                names.append(dir_name)
+        return sorted(names)
     root = Path(source)
     if not root.exists():
         return []
-    return sorted(p.name for p in root.iterdir() if p.is_dir())
+    names = []
+    for p in sorted(root.iterdir()):
+        if not p.is_dir():
+            continue
+        meta = p / "metadata.json"
+        if meta.exists():
+            try:
+                real = json.loads(meta.read_text()).get("username")
+                names.append(real or p.name)
+                continue
+            except (json.JSONDecodeError, OSError):
+                pass
+        names.append(p.name)
+    return names
 
 
 def _render_one(

--- a/services/collections/register_model.py
+++ b/services/collections/register_model.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 from services.collections.registered_model import RegisteredCollectionModel
+from src.collection.collection_artifact_storage import slugify_username
 from services.collections.registry_writer import RegistryWriter
 from src.utils.config import load_config
 
@@ -41,9 +42,11 @@ def register_collection(
     local_root: str = "models/collections",
 ) -> dict:
     # Local layout matches src/collection/collection_artifact_storage.py:
-    # {local_root}/{username}/{outcome}/{candidate}/v{N}/. The `environment`
-    # arg controls the GCS prefix and registry context, not the local path.
-    cand_root = Path(local_root) / username / outcome / candidate
+    # {local_root}/{slugify(username)}/{outcome}/{candidate}/v{N}/.
+    # The `environment` arg controls the GCS prefix and registry context,
+    # not the local path. Real ``username`` is preserved for the registry
+    # row and GCS upload key (see RegisteredCollectionModel).
+    cand_root = Path(local_root) / slugify_username(username) / outcome / candidate
     if not cand_root.is_dir():
         raise FileNotFoundError(f"Candidate dir not found: {cand_root}")
 

--- a/src/collection/collection_artifact_storage.py
+++ b/src/collection/collection_artifact_storage.py
@@ -33,6 +33,7 @@ Path layout per user::
 import json
 import logging
 import pickle
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -42,6 +43,24 @@ import polars as pl
 from src.utils.config import load_config
 
 logger = logging.getLogger(__name__)
+
+
+def slugify_username(username: str) -> str:
+    """Turn a BGG username into a filesystem-safe directory name.
+
+    BGG usernames may contain spaces and other characters that are awkward
+    in paths (e.g. ``"Watch It Played"``). Collapse whitespace and other
+    unsafe runs to single underscores. **Case is preserved** — existing
+    collections are stored under their literal (case-sensitive) username,
+    so lowercasing here would orphan them. The original username is still
+    kept verbatim by callers for the API and display; this only affects
+    the on-disk directory.
+
+    For usernames already safe (no spaces/punctuation — the common case),
+    this is the identity function, so existing directories keep resolving.
+    """
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "_", username.strip()).strip("_")
+    return slug or "_unknown"
 
 
 class CollectionArtifactStorage:
@@ -81,6 +100,7 @@ class CollectionArtifactStorage:
                 via ``Config.get_environment_prefix()``.
         """
         self.username = username
+        self.username_slug = slugify_username(username)
 
         if environment is None:
             project_config = load_config()
@@ -88,7 +108,7 @@ class CollectionArtifactStorage:
         self.environment = environment
 
         self.local_root = Path(local_root)
-        self.base_dir: Path = self.local_root / username
+        self.base_dir: Path = self.local_root / self.username_slug
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
         logger.info(f"Initialized artifact storage for user '{username}'")

--- a/src/collection/collection_pipeline.py
+++ b/src/collection/collection_pipeline.py
@@ -191,8 +191,11 @@ class CollectionPipeline:
         processed = self._process_collection()
         logger.info(f"Processed collection: {processed.height} rows")
 
-        # Step 2: save the processed snapshot (outcome-agnostic)
+        # Step 2: save the processed snapshot (outcome-agnostic). Also
+        # persist the real username in metadata.json so downstream readers
+        # (reports, user pickers) can recover it from the on-disk slug dir.
         self.storage.save_collection(processed)
+        self.storage.save_user_metadata({"username": self.username})
 
         # Step 3: load the game universe (features for every game).
         universe_df = self._load_game_universe()

--- a/src/reports/collection_data.py
+++ b/src/reports/collection_data.py
@@ -142,7 +142,9 @@ def select_candidate(
         4. Raise MissingArtifactsError if nothing is finalized.
     """
     root_str = str(root).rstrip("/")
-    user_dir = f"{root_str}/{username}"
+    # The on-disk/GCS directory uses the slugified username; the real
+    # username is still what callers pass in and what we report back.
+    user_dir = f"{root_str}/{slugify_username(username)}"
     user_outcome_dir = f"{user_dir}/{outcome}"
 
     if not _file_exists(user_dir):
@@ -216,13 +218,18 @@ def _read_parquet(uri: str) -> pl.DataFrame:
     return pl.read_parquet(uri)
 
 
+from src.collection.collection_artifact_storage import slugify_username
 from src.collection.viz import extract_finalized_importance
 
 
 def _outcome_root(source: str, username: str, outcome: str) -> str:
-    """Compose the outcome-level URI/path. Trailing slash safe."""
+    """Compose the outcome-level URI/path. Trailing slash safe.
+
+    The dir name on disk is the slugified username; ``username`` here is
+    the real BGG username and is slugified before path composition.
+    """
     base = source.rstrip("/")
-    return f"{base}/{username}/{outcome}"
+    return f"{base}/{slugify_username(username)}/{outcome}"
 
 
 def _candidate_root(


### PR DESCRIPTION
## What

Make every layer of the user-collection pipeline accept BGG usernames with spaces (e.g. `Watch It Played`). Today they fail at the first hop and quietly mis-resolve at later ones.

## Why

`just load "Watch It Played"` was reproducibly broken:

```
usage: load.py [-h] --username USERNAME [--environment ENVIRONMENT]
load.py: error: unrecognized arguments: It Played
```

That's the surface symptom. The underlying problem spans three layers:

| Layer | Bug |
|---|---|
| `justfile` | `{{user}}` interpolated unquoted — shell re-splits on spaces |
| `CollectionArtifactStorage` | Would write to `models/collections/Watch It Played/` — directory name with a space, fragile under any unquoted shell expansion |
| `reports/collection_data.py`, `services/collections/register_model.py` | Compose `local_root / username / ...` from raw username, so `just promote` / report rendering miss spaces-users even when the load succeeds |

## How

1. **`slugify_username(username)`** — case-preserving, collapses non-`[A-Za-z0-9._-]` runs to underscores. **Identity** for the 6 existing users:

   | username | slug |
   |---|---|
   | `phenrickson` | `phenrickson` |
   | `GOBBluth89` | `GOBBluth89` |
   | `Gyges` | `Gyges` |
   | `TomBrewstErr` | `TomBrewstErr` |
   | `VWValker` | `VWValker` |
   | `rahdo` | `rahdo` |
   | `Watch It Played` | `Watch_It_Played` |

2. **`CollectionArtifactStorage.base_dir`** uses the slug; `self.username` stays raw for logs/metadata/display.

3. **`CollectionPipeline.run_full_pipeline`** writes `metadata.json` (`{"username": "Watch It Played"}`) after `save_collection`, so slug → real-name is recoverable from the artifact tree.

4. **`reports/render.py:_list_users`** reads `metadata.json` to return real BGG usernames; falls back to dir name when metadata is missing (so existing artifacts continue working).

5. **`reports/collection_data.py` (`_load_outcome`, `_outcome_root`)** and **`services/collections/register_model.py`** slugify when composing local paths.

6. **`justfile`**: every `{{user}}` interpolation quoted. Path-building recipes (`sync-artifacts`, `pull-artifacts`, `promote-all`, `users-sweep`) derive the slug via the same function — single source of truth.

## Production impact

**None.** Verified before pushing:

- `slugify_username()` is identity for all 6 production users → on-disk and GCS paths unchanged.
- `build-collection-reports.yml` (daily): discovers users via `gsutil ls gs://.../collections/`, gets the same dir names as before, slugify is identity → no path change.
- `run-collection-scoring.yml` (daily): hits Cloud Run, doesn't touch my changed files.
- `docker-collections-build.yml` will re-fire on merge to `main` because the diff touches `services/collections/register_model.py`. New image gets built and deployed as a new Cloud Run revision, but `services/collections/main.py` does not import `register_model.py` at runtime — the running container is byte-equivalent to current.
- `run-training.yml` doesn't trigger from this branch.

## Test

```
$ uv run python -c "from reports.render import _list_users; print(_list_users('local'))"
['GOBBluth89', 'Gyges', 'TomBrewstErr', 'VWValker', 'Watch It Played', 'phenrickson', 'rahdo']

$ just --dry-run load "Watch It Played"
uv run python -m src.collection.load --username "Watch It Played" --environment prod

$ just --dry-run sync-artifacts "Watch It Played"
slug=$(uv run python -c '...slugify...' "Watch It Played")
src="models/collections/$slug"   # -> models/collections/Watch_It_Played
dst="gs://.../collections/$slug"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)