### PR TITLE
Migrate GCS artifact sync from gsutil to gcloud storage

### DIFF
--- a/.github/workflows/build-collection-reports.yml
+++ b/.github/workflows/build-collection-reports.yml
@@ -66,7 +66,7 @@ jobs:
               | python3 -c "import sys, json; print(json.dumps([u.strip() for u in sys.stdin.read().splitlines() if u.strip()]))")
           else
             # Discover by listing the gs:// prefix.
-            users=$(gsutil ls "gs://${{ env.GCP_PROJECT_ID }}/${{ steps.env.outputs.env_name }}/collections/" 2>/dev/null \
+            users=$(gcloud storage ls "gs://${{ env.GCP_PROJECT_ID }}/${{ steps.env.outputs.env_name }}/collections/" 2>/dev/null \
               | sed -e 's|/$||' \
               | xargs -n1 basename \
               | python3 -c "import sys, json; print(json.dumps([u for u in sys.stdin.read().splitlines() if u]))")
@@ -185,7 +185,7 @@ jobs:
       # part of this run keep their last-published HTML.
       - name: Restore previously published HTMLs from GCS
         run: |
-          gsutil -m rsync -r \
+          gcloud storage rsync -r \
             "gs://${{ env.GCP_PROJECT_ID }}/${{ needs.discover.outputs.env_name }}/reports/" \
             reports/_output/ 2>&1 || echo "(no prior bundle in gs://; first run)"
 
@@ -213,7 +213,7 @@ jobs:
       # from it. This is what makes partial renders safe.
       - name: Mirror final bundle to GCS
         run: |
-          gsutil -m rsync -r reports/_output/ \
+          gcloud storage rsync -r reports/_output/ \
             "gs://${{ env.GCP_PROJECT_ID }}/${{ needs.discover.outputs.env_name }}/reports/"
 
       - name: Configure GitHub Pages

--- a/.github/workflows/build-model-reports.yml
+++ b/.github/workflows/build-model-reports.yml
@@ -56,7 +56,7 @@ jobs:
               | tr ',' '\n' | sed 's/^ *//; s/ *$//' | grep -v '^$' \
               | python3 -c "import sys, json; print(json.dumps([u.strip() for u in sys.stdin.read().splitlines() if u.strip()]))")
           else
-            users=$(gsutil ls "gs://${{ env.GCP_PROJECT_ID }}/${{ steps.env.outputs.env_name }}/collections/" 2>/dev/null \
+            users=$(gcloud storage ls "gs://${{ env.GCP_PROJECT_ID }}/${{ steps.env.outputs.env_name }}/collections/" 2>/dev/null \
               | sed -e 's|/$||' \
               | xargs -n1 basename \
               | python3 -c "import sys, json; print(json.dumps([u for u in sys.stdin.read().splitlines() if u]))")
@@ -146,7 +146,7 @@ jobs:
         run: mkdir -p reports/_output/model
       - name: Restore previously published bundle from GCS
         run: |
-          gsutil -m rsync -r \
+          gcloud storage rsync -r \
             "gs://${{ env.GCP_PROJECT_ID }}/${{ needs.discover.outputs.env_name }}/reports/" \
             reports/_output/ 2>&1 || echo "(no prior bundle in gs://; first run)"
       - name: Download per-user artifacts
@@ -168,7 +168,7 @@ jobs:
             --output-dir reports/_output
       - name: Mirror final bundle to GCS
         run: |
-          gsutil -m rsync -r reports/_output/ \
+          gcloud storage rsync -r reports/_output/ \
             "gs://${{ env.GCP_PROJECT_ID }}/${{ needs.discover.outputs.env_name }}/reports/"
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/publish-static-reports.yml
+++ b/.github/workflows/publish-static-reports.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Stage current published bundle from GCS
         run: |
           mkdir -p reports/_output
-          gsutil -m rsync -r \
+          gcloud storage rsync -r \
             "gs://${{ env.GCP_PROJECT_ID }}/${{ steps.env.outputs.env_name }}/reports/" \
             reports/_output/ 2>&1 || echo "(no prior bundle in gs://; first run)"
 
@@ -76,7 +76,7 @@ jobs:
 
       - name: Mirror updated bundle back to GCS
         run: |
-          gsutil -m rsync -r reports/_output/ \
+          gcloud storage rsync -r reports/_output/ \
             "gs://${{ env.GCP_PROJECT_ID }}/${{ steps.env.outputs.env_name }}/reports/"
 
       - name: Configure GitHub Pages

--- a/justfile
+++ b/justfile
@@ -21,9 +21,11 @@ local_root := "models/collections"
 default:
     @just --list
 
-# Fetch a user's collection from BGG and upsert into BigQuery.
-# Run this before `sweep` for a user whose collection has not been
-# loaded yet.
+# Refresh a user's collection: fetch their latest collection from BGG and
+# upsert it into BigQuery. Run this to pull in new/changed games for an
+# existing user, or before `sweep` for a user not yet loaded.
+#   just load                  # default username
+#   just load alice            # a specific user
 load user=username:
     uv run python -m src.collection.load \
         --username "{{user}}" --environment {{environment}}
@@ -312,9 +314,9 @@ sync-artifacts user=username prune="":
     fi
     echo "syncing $src -> $dst"
     if [ -n "{{prune}}" ]; then
-        gsutil -m rsync -r -d "$src" "$dst"
+        gcloud storage rsync -r --delete-unmatched-destination-objects "$src" "$dst"
     else
-        gsutil -m rsync -r "$src" "$dst"
+        gcloud storage rsync -r "$src" "$dst"
     fi
 
 # Sync every local user's collection artifacts to GCS. Skips users with
@@ -349,9 +351,9 @@ pull-artifacts user=username prune="":
     mkdir -p "$dst"
     echo "pulling $src -> $dst"
     if [ -n "{{prune}}" ]; then
-        gsutil -m rsync -r -d "$src" "$dst"
+        gcloud storage rsync -r --delete-unmatched-destination-objects "$src" "$dst"
     else
-        gsutil -m rsync -r "$src" "$dst"
+        gcloud storage rsync -r "$src" "$dst"
     fi
 
 # Pull every user under gs://.../collections/ into the local tree.
@@ -359,7 +361,7 @@ pull-artifacts user=username prune="":
 pull-artifacts-all prune="":
     #!/usr/bin/env bash
     failed=()
-    users=$(gsutil ls "{{gcs_artifacts_root}}/" 2>/dev/null \
+    users=$(gcloud storage ls "{{gcs_artifacts_root}}/" 2>/dev/null \
         | sed -e 's|/$||' -e "s|^{{gcs_artifacts_root}}/||")
     if [ -z "$users" ]; then
         echo "No users found at {{gcs_artifacts_root}}/" >&2

--- a/src/collection/collection_artifact_storage.py
+++ b/src/collection/collection_artifact_storage.py
@@ -880,10 +880,8 @@ class CollectionArtifactStorage:
         registration["finalized_at"] = datetime.now().isoformat()
         self._upload_json(reg_path, registration)
 
-        logger.info(
-            f"Saved finalized pipeline to {self.base_dir / finalized_path}"
-        )
-        return f"{self.base_dir / finalized_path}"
+        logger.info(f"Saved finalized pipeline to {finalized_path}")
+        return finalized_path
 
     def load_finalized_pipeline(
         self,


### PR DESCRIPTION
## Summary

Migrates all GCS artifact syncing from deprecated `gsutil` to `gcloud storage`, and fixes a doubled path string in `save_finalized_pipeline`.

### Why
`just sync-artifacts` was crashing mid-upload with "python closed unexpectedly". Root cause: `gsutil`'s multiprocessing rsync is unstable under Python 3.14 on macOS ([bugs.python.org/issue33725](https://bugs.python.org/issue33725)). `gcloud storage rsync` has no such issue. gsutil is also deprecated in favor of `gcloud storage`.

### Changes
- **justfile**: `sync-artifacts`, `pull-artifacts`, `pull-artifacts-all` → `gcloud storage`. Flag mapping: `-d` → `--delete-unmatched-destination-objects`; dropped `-m` (gcloud parallelizes by default).
- **workflows**: `build-collection-reports`, `build-model-reports` (restore/mirror bundle rsyncs + discover `ls`) and `publish-static-reports` → `gcloud storage`. All were `-m rsync -r` with no prune, mapping directly to `gcloud storage rsync -r`.
- **collection_artifact_storage.py**: `save_finalized_pipeline` logged/returned a doubled path (`models/collections/<user>/models/collections/<user>/...`) because `_upload_pickle` already returns the full path. The `.pkl` was always written to the correct location; only the returned/logged string was wrong.

### Verification
- `just sync-artifacts phenrickson` runs clean, exit 0, no crash — v4 with `finalized.pkl` confirmed in GCS.
- All three workflow YAMLs validate; discover `ls | sed | basename` parsing unchanged (identical output format).
- Workflow changes are CI-only and untested locally; next CI run will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)