### PR TITLE
New on BGG section + collection game-card sections

### DIFF
--- a/justfile
+++ b/justfile
@@ -290,6 +290,14 @@ render-index source="local":
 render-sandbox report="predictions":
     uv run python -m reports.render --fixture --report {{report}}
 
+# Render the interactive collection explorer (faceted table + themed game-card
+# sections) for a user. Output: reports/_output/collection/<slug>.html.
+#   just render-collection                 # default user
+#   just render-collection rahdo
+render-collection user=username outcome="own":
+    uv run python -m reports.render --report collection \
+        --username "{{user}}" --outcome {{outcome}}
+
 # --- Selections workflow (Spain trip menu) ---
 #
 # Step 1: launch the game-selector Streamlit page. Filter a collection,

--- a/reports/_collection_explorer.qmd
+++ b/reports/_collection_explorer.qmd
@@ -16,12 +16,11 @@ print(
 ```
 
 ```{=html}
-<div class="explorer-controls">
-  <div class="explorer-controls-title">Filters</div>
-  <!-- <p class="explorer-controls-help">Click values to filter. Chips within a group combine with <strong>or</strong>; groups combine with <strong>and</strong>. Numeric filters keep games with unknown values.</p> -->
+<details class="explorer-controls">
+  <summary class="explorer-controls-title">Filters</summary>
   <div id="explorer-filters" class="explorer-filters"></div>
   <div id="explorer-controls-footer" class="explorer-controls-footer"></div>
-</div>
+</details>
 ```
 
 ```{=html}
@@ -274,6 +273,12 @@ print(
       var n = parseFloat(String(cell).replace(/[^0-9.\-]/g,''));
       return isNaN(n) ? null : n;
     }
+    // Plain text for lexical sort: strip HTML tags (e.g. the Game column's
+    // <a> link) so we compare the visible name, not the markup.
+    function sortText(cell){
+      if(cell && typeof cell==='object') return '';
+      return String(cell).replace(/<[^>]*>/g, '').trim().toLowerCase();
+    }
 
     // ---- render table ----
     function render(){
@@ -282,7 +287,7 @@ print(
         filtered = filtered.slice().sort(function(a,b){
           var ak=sortKey(a[sortIdx]), bk=sortKey(b[sortIdx]);
           if(ak!==null && bk!==null) return (ak-bk)*sortDir;
-          return String(a[sortIdx]).localeCompare(String(b[sortIdx]))*sortDir;
+          return sortText(a[sortIdx]).localeCompare(sortText(b[sortIdx]))*sortDir;
         });
       }
       var total = filtered.length;

--- a/reports/collection_report.qmd
+++ b/reports/collection_report.qmd
@@ -53,9 +53,9 @@ header to sort.
 #| label: sections
 #| include: false
 from src.reports.collection_sections import build_sections
-from src.reports.game_cards import game_cards_html
+from src.reports.game_cards import game_strips_html
 
-_sections = build_sections(data.collection, data.games, top_n=6)
+_sections = build_sections(data.collection, data.games, top_n=10)
 _by_group = {}
 for grp, label, ids in _sections:
     _by_group.setdefault(grp, []).append((label, ids))
@@ -64,9 +64,9 @@ for grp, label, ids in _sections:
 def _render_group(group_name):
     parts = []
     for label, ids in _by_group.get(group_name, []):
-        html = game_cards_html(data.games, ids, tier="collection")
+        html = game_strips_html(data.games, ids)
         if html:
-            parts.append(f"### {label}\n\n{html}")
+            parts.append(f"### {label} ({len(ids)})\n\n{html}")
     return "\n\n".join(parts)
 ```
 

--- a/reports/collection_report.qmd
+++ b/reports/collection_report.qmd
@@ -5,7 +5,7 @@ format:
   html:
     toc: true
     toc-location: right
-    toc-depth: 2
+    toc-depth: 3
     code-fold: true
     code-summary: "Show the code"
     embed-resources: true
@@ -42,9 +42,48 @@ print(
 Explore **`{python} USERNAME`**'s board game collection. Use the filters to
 narrow by player count, complexity, and playing time.
 
-## Games {#explorer-table}
+# Collection {#explorer-table}
 
-Explore the collection below. Use the filters to narrow the list; click a column
+Explore the collection below. Expand the filters to narrow the list; click a column
 header to sort.
 
 {{< include _collection_explorer.qmd >}}
+
+```{python}
+#| label: sections
+#| include: false
+from src.reports.collection_sections import build_sections
+from src.reports.game_cards import game_cards_html
+
+_sections = build_sections(data.collection, data.games, top_n=6)
+_by_group = {}
+for grp, label, ids in _sections:
+    _by_group.setdefault(grp, []).append((label, ids))
+
+
+def _render_group(group_name):
+    parts = []
+    for label, ids in _by_group.get(group_name, []):
+        html = game_cards_html(data.games, ids, tier="collection")
+        if html:
+            parts.append(f"### {label}\n\n{html}")
+    return "\n\n".join(parts)
+```
+
+# Player Counts
+
+The user's top-rated owned games at each player count.
+
+```{python}
+#| output: asis
+print(_render_group("Recommendations") or "_No games._")
+```
+
+# Game Types
+
+The user's top-rated owned games among different types of games.
+
+```{python}
+#| output: asis
+print(_render_group("Game Types") or "_No games._")
+```

--- a/reports/predictions_report.qmd
+++ b/reports/predictions_report.qmd
@@ -6,7 +6,7 @@ format:
   html:
     toc: true
     toc-location: right
-    toc-depth: 2
+    toc-depth: 3
     code-fold: true
     code-summary: "Show the code"
     embed-resources: true
@@ -56,7 +56,59 @@ release (categories, mechanics, designers, publishers, playing time, estimated c
 For more on the model's findings and evaluation, see the companion
 [Model Report](`{python} f"model/{USERNAME_SLUG}.html"`).
 
-# Predictions {#predictions}
+```{python}
+#| label: predictions-setup
+#| include: false
+# Shared setup for the prediction sections below: build the `upcoming` frame
+# (recent/upcoming releases scored by the model) and the status lookup once.
+status_lookup = build_status_lookup(data.collection)
+finalize_through = arts.registration.get("finalize_through")
+upcoming = arts.upcoming_predictions.join(data.games, on="game_id", how="inner")
+if finalize_through is not None:
+    upcoming = upcoming.filter(pl.col("year_published") > int(finalize_through))
+upcoming = upcoming.sort("predicted_prob", descending=True)
+```
+
+# New on BGG {#new-on-bgg}
+
+Games recently added to BoardGameGeek that the model has scored for the first
+time in the **last 7 days** — a running look at what the model makes of brand-new
+releases as they appear. The **Prediction** is the model's call at its tuned
+threshold.
+
+```{python}
+#| label: predictions-new-7d
+#| column: page-right
+if "is_new_7d" in upcoming.columns:
+    _new = upcoming.filter(pl.col("is_new_7d")).sort("predicted_prob", descending=True)
+else:
+    _new = upcoming.head(0)
+
+if _new.height == 0:
+    print("_No games newly scored in the last 7 days._")
+else:
+    from src.reports.tables import format_new_games_table
+
+    _new_table = format_new_games_table(_new, threshold=arts.threshold, top_n=50)
+    # Columns: Image0 | Game1 | Description2 | Pr(Yes)3 | Prediction4
+    itables_show(
+        _new_table,
+        paging=True,
+        pageLength=10,
+        classes="display compact",
+        columnDefs=[
+            {"className": "dt-center", "targets": [0, 3, 4]},
+            {"width": "70px", "targets": [0]},
+            {"width": "220px", "targets": [1]},
+            {"width": "80px", "targets": [3]},
+            {"width": "110px", "targets": [4]},
+        ],
+        style="width: 100%",
+        allow_html=True,
+    )
+```
+
+# Top Picks {#top-picks}
 
 ## New and Upcoming Games
 
@@ -71,17 +123,7 @@ already in the user's collection.
 ```{python}
 #| label: predictions-upcoming
 #| column: page-right
-status_lookup = build_status_lookup(data.collection)
-
-# The model was trained on data through `finalize_through`, so anything
-# published in or before that year is in-sample. "New and Upcoming"
-# means strictly after.
-finalize_through = arts.registration.get("finalize_through")
-upcoming = arts.upcoming_predictions.join(data.games, on="game_id", how="inner")
-if finalize_through is not None:
-    upcoming = upcoming.filter(pl.col("year_published") > int(finalize_through))
-upcoming = upcoming.sort("predicted_prob", descending=True)
-
+# `upcoming` and `status_lookup` are built in the predictions-setup cell above.
 from itables import JavascriptFunction
 
 _upcoming_table = format_predictions_with_images(

--- a/reports/styles.css
+++ b/reports/styles.css
@@ -247,9 +247,19 @@ table.topn-by-year tbody tr:hover td.owned {
   background:color-mix(in srgb, currentColor 3.5%, transparent);
 }
 .explorer-controls-title {
-  margin:0 0 .2rem; font-size:.82rem; font-weight:700; text-transform:uppercase;
+  margin:0; font-size:.82rem; font-weight:700; text-transform:uppercase;
   letter-spacing:.06em; opacity:.85;
+  cursor:pointer; user-select:none; list-style:none;
+  display:flex; align-items:center; gap:.45rem;
 }
+.explorer-controls-title::-webkit-details-marker { display:none; }
+/* disclosure caret that rotates when open */
+.explorer-controls-title::before {
+  content:"▸"; font-size:.7rem; opacity:.7; transition:transform .12s ease;
+}
+.explorer-controls[open] .explorer-controls-title::before { transform:rotate(90deg); }
+/* space the groups from the summary only when open */
+.explorer-controls[open] .explorer-filters { margin-top:.75rem; }
 .explorer-controls-help { margin:0 0 .85rem; font-size:.8rem; opacity:.6; max-width:60ch; text-transform:none; }
 
 /* Filter groups inside the surface */
@@ -301,11 +311,24 @@ table.topn-by-year tbody tr:hover td.owned {
 .explorer-empty { opacity:.65; font-style:italic; }
 
 /* Table — tighter rows, quiet lines, no mid-cell wrapping on data columns */
+/* Table sits directly on the page ground (transparent), like the other
+   report tables — so it never reads as a dark rectangle pasted on the
+   blue-ish page. The sticky header needs an opaque fill to cover rows as
+   they scroll under it; inherit the actual page background color. */
+.explorer-table,
+.explorer-table thead, .explorer-table tbody, .explorer-table tr,
+.explorer-table th, .explorer-table td {
+  background:transparent !important; background-color:transparent !important;
+  background-image:none !important;
+  --bs-table-bg: transparent !important;
+  --bs-table-accent-bg: transparent !important;
+  --bs-table-striped-bg: transparent !important;
+}
 .explorer-table { width:100%; border-collapse:collapse; font-size:.88rem; }
-.explorer-table thead th { position:sticky; top:0; z-index:1; text-align:left; padding:.5rem .65rem; border-bottom:1px solid var(--exp-line); cursor:pointer; user-select:none; white-space:nowrap; font-size:.78rem; font-weight:700; text-transform:uppercase; letter-spacing:.03em; background:var(--bs-body-bg,#1e222b); }
+.explorer-table thead th { position:sticky; top:0; z-index:1; text-align:left; padding:.5rem .65rem; border-bottom:2px solid var(--exp-line); cursor:pointer; user-select:none; white-space:nowrap; font-size:.78rem; font-weight:700; text-transform:uppercase; letter-spacing:.03em; background:#0f0f1a !important; }
 .explorer-table thead th:hover { color:var(--exp-accent); }
-.explorer-table tbody td { padding:.4rem .65rem; border-bottom:1px solid var(--exp-line-soft); vertical-align:middle; }
-.explorer-table tbody tr:hover { background:var(--exp-hover); }
+.explorer-table tbody td { padding:.4rem .65rem; border-bottom:1px solid var(--exp-line-soft); vertical-align:middle; background:transparent; }
+.explorer-table tbody tr:hover td { background:var(--exp-hover) !important; }
 .explorer-table td.dt-center, .explorer-table th.dt-center { text-align:center; }
 /* Numeric/count columns never wrap; game titles may */
 .explorer-table td.dt-center { white-space:nowrap; }
@@ -326,3 +349,38 @@ table.topn-by-year tbody tr:hover td.owned {
 .card-meta { display:flex; flex-wrap:wrap; gap:.35rem .9rem; align-items:center; }
 .card-meta-item { display:inline-flex; align-items:center; gap:.35rem; font-size:.8rem; }
 .card-meta-label { font-size:.66rem; font-weight:700; text-transform:uppercase; letter-spacing:.04em; opacity:.55; }
+
+/* Themed 'top games' sections — tile cards, dark-theme tuned. Mirrors the
+   Spain report's .tile markup but uses the collection report's dark ground. */
+
+/* Subsection headers (Best at N / Economic / …) — a full-width banded header
+   so each block clearly breaks from the one above. Accent chip + rule. */
+#quarto-document-content h3 {
+  margin:2.75rem 0 1rem;
+  padding:.5rem .9rem;
+  font-size:1.05rem; font-weight:700; line-height:1.1;
+  text-transform:uppercase; letter-spacing:.06em;
+  color:#e6ecff;
+  background:linear-gradient(90deg, rgba(76,126,243,.22), rgba(76,126,243,.02));
+  border-left:4px solid #4c7ef3;
+  border-radius:.35rem;
+}
+/* First subsection right under a group H1 shouldn't have the big top gap. */
+#quarto-document-content h1 + p + div h3:first-child,
+#quarto-document-content h3:first-of-type { margin-top:1.5rem; }
+
+/* Compact tiles: shorter cover + description clamped to one line + tighter
+   body, so sections don't eat so much vertical space. */
+.tile-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(230px, 1fr)); gap:.75rem; margin:.6rem 0 1.25rem; }
+.tile { display:flex; flex-direction:column; background:rgba(255,255,255,.03); border:1px solid rgba(255,255,255,.10); border-radius:.55rem; overflow:hidden; text-decoration:none !important; color:#e2e8f0 !important; transition:transform .14s ease, border-color .14s ease, box-shadow .14s ease; }
+.tile:hover { transform:translateY(-2px); border-color:#4c7ef3; box-shadow:0 8px 18px rgba(0,0,0,.35); }
+.tile-cover { aspect-ratio:16/6; background:rgba(255,255,255,.06); overflow:hidden; }
+.tile-cover img { width:100%; height:100%; object-fit:cover; display:block; }
+.tile-body { padding:.55rem .7rem .6rem; display:flex; flex-direction:column; gap:.3rem; flex:1; }
+.tile-name { font-weight:700; font-size:.92rem; line-height:1.15; }
+.tile-year { color:#94a3b8; font-weight:400; margin-left:.3rem; font-size:.82em; }
+.tile-desc { font-size:.76rem; color:#94a3b8; line-height:1.3; display:-webkit-box; -webkit-line-clamp:1; -webkit-box-orient:vertical; overflow:hidden; }
+.tile-meta { margin-top:auto; display:flex; flex-direction:column; gap:.25rem; padding-top:.4rem; border-top:1px solid rgba(255,255,255,.08); }
+.tile-meta-item { display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; font-size:.78rem; }
+.tile-meta-k { font-size:.62rem; font-weight:700; text-transform:uppercase; letter-spacing:.05em; opacity:.55; min-width:4.6rem; }
+.tile-time { font-variant-numeric:tabular-nums; }

--- a/reports/styles.css
+++ b/reports/styles.css
@@ -398,3 +398,12 @@ table.topn-by-year tbody tr:hover td.owned {
 .strip-meta { display:flex; align-items:center; gap:.9rem; flex-shrink:0; }
 .strip-meta-item { display:inline-flex; align-items:center; }
 .strip-time { font-size:.8rem; color:#94a3b8; font-variant-numeric:tabular-nums; min-width:5.5rem; text-align:right; }
+
+/* Prediction pill (New on BGG table): model's call at the tuned threshold. */
+.pred-pill { display:inline-block; padding:.15rem .6rem; border-radius:1rem; font-size:.74rem; font-weight:700; text-transform:uppercase; letter-spacing:.03em; }
+.pred-yes { background:#15803d; color:#fff; }
+.pred-no { background:rgba(255,255,255,.10); color:#cbd5e1; }
+
+/* Cover thumbnails in prediction tables: fixed box, centered, consistent. */
+.cover-cell { display:flex; align-items:center; justify-content:center; width:100%; min-height:56px; }
+.cover-thumb { height:52px; width:52px; object-fit:cover; border-radius:4px; display:block; }

--- a/reports/styles.css
+++ b/reports/styles.css
@@ -384,3 +384,17 @@ table.topn-by-year tbody tr:hover td.owned {
 .tile-meta-item { display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; font-size:.78rem; }
 .tile-meta-k { font-size:.62rem; font-weight:700; text-transform:uppercase; letter-spacing:.05em; opacity:.55; min-width:4.6rem; }
 .tile-time { font-variant-numeric:tabular-nums; }
+
+/* Compact horizontal-strip list (collection 'top games' sections). One thin
+   full-width row per game: thumbnail left, name + meta beside it. */
+.strip-list { display:flex; flex-direction:column; gap:.4rem; margin:.5rem 0 1.5rem; }
+.strip { display:flex; align-items:center; gap:.8rem; padding:.4rem .6rem; border:1px solid rgba(255,255,255,.08); border-radius:.45rem; background:rgba(255,255,255,.02); text-decoration:none !important; color:#e2e8f0 !important; transition:background .12s ease, border-color .12s ease; }
+.strip:hover { background:rgba(76,126,243,.08); border-color:#4c7ef3; }
+.strip-cover { flex:0 0 auto; width:56px; height:42px; border-radius:.3rem; overflow:hidden; background:rgba(255,255,255,.06); }
+.strip-cover img { width:100%; height:100%; object-fit:cover; display:block; }
+.strip-main { flex:1 1 auto; min-width:0; display:flex; align-items:center; justify-content:space-between; gap:1rem; flex-wrap:wrap; }
+.strip-name { flex:1 1 auto; min-width:0; max-width:22rem; font-weight:600; font-size:.9rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.strip-name .tile-year { color:#94a3b8; font-weight:400; font-size:.85em; margin-left:.35rem; }
+.strip-meta { display:flex; align-items:center; gap:.9rem; flex-shrink:0; }
+.strip-meta-item { display:inline-flex; align-items:center; }
+.strip-time { font-size:.8rem; color:#94a3b8; font-variant-numeric:tabular-nums; min-width:5.5rem; text-align:right; }

--- a/src/reports/collection_sections.py
+++ b/src/reports/collection_sections.py
@@ -1,0 +1,90 @@
+"""Themed 'top games' sections for the collection report.
+
+Each section is the user's top-N owned games (by their rating) matching a
+criterion — a best-player-count bucket or a category/mechanic. Returns
+ordered game_id lists that the report renders as tile cards via
+``game_cards_html``.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def _best_counts(raw) -> set[int]:
+    if raw is None:
+        return set()
+    return {int(t.strip()) for t in str(raw).split(",") if t.strip().isdigit()}
+
+
+def _has(seq, value) -> bool:
+    return bool(seq) and value in seq
+
+
+# Player-count recommendation buckets: label -> predicate over the best set.
+_PLAYER_BUCKETS = [
+    ("Best at 2 Players", lambda b: 2 in b),
+    ("Best at 3–4 Players", lambda b: bool(b & {3, 4})),
+    ("Best at 5 Players", lambda b: 5 in b),
+    ("Best at 6+ Players", lambda b: any(n >= 6 for n in b)),
+]
+
+# Game-type buckets: label -> (field, value). field in categories/mechanics.
+_TYPE_BUCKETS = [
+    ("Economic", "categories", "Economic"),
+    ("War", "categories", "Wargame"),
+    ("Cooperative", "mechanics", "Cooperative Game"),
+    ("Party", "categories", "Party Game"),
+]
+
+
+def _owned_with_rating(collection: pl.DataFrame, games: pl.DataFrame) -> list[dict]:
+    """Owned games joined to metadata, each with a `_rating` sort key."""
+    if collection.height == 0:
+        return []
+    owned = (
+        collection.filter(pl.col("owned")) if "owned" in collection.columns else collection
+    )
+    rating = {
+        int(r["game_id"]): (r.get("user_rating") or 0.0) for r in owned.iter_rows(named=True)
+    }
+    meta = {int(r["game_id"]): r for r in games.iter_rows(named=True)}
+    out = []
+    for gid in rating:
+        m = meta.get(gid)
+        if m is None:
+            continue
+        d = dict(m)
+        d["_rating"] = float(rating[gid] or 0.0)
+        out.append(d)
+    # highest rating first; ties broken by name for stable order
+    out.sort(key=lambda d: (-d["_rating"], str(d.get("name") or "")))
+    return out
+
+
+def build_sections(
+    collection: pl.DataFrame, games: pl.DataFrame, top_n: int = 6
+) -> list[tuple[str, str, list[int]]]:
+    """Return ordered ``(group, label, game_ids)`` sections.
+
+    group is "Recommendations" or "Game Types"; game_ids are the user's top
+    `top_n` owned games (by rating) matching the section, best first.
+    """
+    rows = _owned_with_rating(collection, games)
+    sections: list[tuple[str, str, list[int]]] = []
+
+    for label, pred in _PLAYER_BUCKETS:
+        ids = [
+            int(d["game_id"])
+            for d in rows
+            if pred(_best_counts(d.get("best_player_counts")))
+        ][:top_n]
+        sections.append(("Recommendations", label, ids))
+
+    for label, field, value in _TYPE_BUCKETS:
+        ids = [
+            int(d["game_id"]) for d in rows if _has(d.get(field), value)
+        ][:top_n]
+        sections.append(("Game Types", label, ids))
+
+    return sections

--- a/src/reports/format.py
+++ b/src/reports/format.py
@@ -56,8 +56,12 @@ def bgg_link(game_id: int, name: str, year: int | None) -> str:
 
 def img_tag(url: str | None) -> str:
     if not url or (isinstance(url, float) and pd.isna(url)):
-        return ""
-    return f'<img src="{url}" style="height:64px;width:auto;border-radius:4px;" />'
+        return '<div class="cover-cell"></div>'
+    return (
+        f'<div class="cover-cell">'
+        f'<img class="cover-thumb" src="{url}" loading="lazy" alt="" />'
+        f"</div>"
+    )
 
 
 def truncate(text: str | None, max_len: int = 220) -> str:

--- a/src/reports/game_cards.py
+++ b/src/reports/game_cards.py
@@ -226,3 +226,43 @@ def game_cards_html(games: pl.DataFrame, game_ids: list[int], tier: str = "") ->
     if not cards:
         return ""
     return '<div class="tile-grid">' + "".join(cards) + "</div>"
+
+
+def game_strips_html(
+    games: pl.DataFrame, game_ids: list[int], complexity: str = "label"
+) -> str:
+    """Compact horizontal-strip list: one thin full-width row per game —
+    small cover thumbnail on the left, name + year and a meta row (recommended
+    player badges · complexity · playtime) beside it. Shows every id in order;
+    skips ids absent from `games`. Whole row links to BGG.
+
+    complexity="label" (default) shows the tier chip (Light..Heavy); "number"
+    shows the numeric weight chip.
+    """
+    if not game_ids or games is None or games.height == 0:
+        return ""
+    cx_fn = complexity_chip if complexity == "number" else complexity_chip_labeled
+    by_id = {int(r["game_id"]): r for r in games.iter_rows(named=True)}
+    rows = []
+    for gid in game_ids:
+        row = by_id.get(int(gid))
+        if row is None:
+            continue
+        src = _cover_data_uri(row.get("image") or row.get("thumbnail"))
+        img_html = f'<img src="{src}" loading="lazy" alt=""/>' if src else ""
+        rows.append(
+            f'<a class="strip" '
+            f'href="https://boardgamegeek.com/boardgame/{int(gid)}" '
+            f'target="_blank" rel="noopener">'
+            f'<div class="strip-cover">{img_html}</div>'
+            f'<div class="strip-main">'
+            f'<div class="strip-name">{_name_year(gid, row.get("name") or row.get("game_name"), row.get("year_published"))}</div>'
+            f'<div class="strip-meta">'
+            f'<span class="strip-meta-item">{player_badges(row.get("best_player_counts"), row.get("recommended_player_counts"))}</span>'
+            f'<span class="strip-meta-item">{cx_fn(row.get("average_weight"))}</span>'
+            f'<span class="strip-meta-item strip-time">{_playtime(row)}</span>'
+            f'</div></div></a>'
+        )
+    if not rows:
+        return ""
+    return '<div class="strip-list">' + "".join(rows) + "</div>"

--- a/src/reports/tables.py
+++ b/src/reports/tables.py
@@ -247,6 +247,49 @@ def format_predictions_with_images(
     return pd.DataFrame(rows)
 
 
+def format_new_games_table(
+    df: pl.DataFrame, *, threshold: float | None, top_n: int = 50
+) -> pd.DataFrame:
+    """New-on-BGG table: Image | Game | Description | Pr(Yes) | Prediction.
+
+    No Rank column. `Prediction` is the model's call at `threshold`
+    (Pr(Yes) >= threshold -> "Would own", else "Pass"), shown as a pill.
+    """
+    view = df.head(top_n).to_pandas()
+    ids = view["game_id"].tolist()
+    images = view["image"].tolist() if "image" in view.columns else [None] * len(view)
+    names = view["name"].tolist() if "name" in view.columns else [""] * len(view)
+    years = (
+        view["year_published"].tolist()
+        if "year_published" in view.columns
+        else [None] * len(view)
+    )
+    descs = (
+        view["description"].tolist() if "description" in view.columns else [""] * len(view)
+    )
+    probs = (
+        view["predicted_prob"].tolist()
+        if "predicted_prob" in view.columns
+        else view["proba"].tolist()
+    )
+    thr = 0.5 if threshold is None else float(threshold)
+
+    def _pred(p) -> str:
+        if float(p) >= thr:
+            return '<span class="pred-pill pred-yes">Yes</span>'
+        return '<span class="pred-pill pred-no">No</span>'
+
+    return pd.DataFrame(
+        {
+            "Image": [img_tag(u) for u in images],
+            "Game": [bgg_link(g, n, y) for g, n, y in zip(ids, names, years)],
+            "Description": [truncate(d) for d in descs],
+            "Pr(Yes)": [round(float(p), 3) for p in probs],
+            "Prediction": [_pred(p) for p in probs],
+        }
+    )
+
+
 def format_menu_table(
     collection: pl.DataFrame,
     games: pl.DataFrame,


### PR DESCRIPTION
## Summary

Builds on the collection-report work with a new predictions-report section and themed collection sections.

**Predictions report**
- **New on BGG** — new lead section listing games newly scored by the model in the last 7 days (`is_new_7d`), with a **Yes/No prediction pill** based on the model's tuned threshold (from `threshold.json`), no Rank column.
- Reorganized: **Top Picks** now groups *New and Upcoming Games* + *Older Games to Check Out*; shared setup cell builds `upcoming`/`status_lookup` once.
- Cover thumbnails render in a fixed, centered box (`.cover-cell`/`.cover-thumb`) so rows align — applies to all prediction tables.

**Collection report**
- Themed sections below the explorer: **Player Counts** (Best at 2 / 3–4 / 5 / 6+) and **Game Types** (Economic / War / Cooperative / Party), each the user's top games by rating rendered as compact **horizontal-strip rows** (`game_strips_html`), capped at 10.
- Explorer polish: collapsible filter panel (collapsed by default), transparent table over the page ground, name-column sort by visible text, banded subsection headers.

**Shared / tooling**
- `src/reports/collection_sections.py` (`build_sections`), `game_strips_html`, `format_new_games_table`.
- `just render-collection <user>` recipe.

## Publish impact
- CI (`build-collection-reports.yml`) renders the **predictions** report → the New on BGG / Top Picks / centered-cover changes go live on merge.
- The **collection** report and strip sections are not auto-rendered by CI; they land as code and render locally via `just render-collection` until wired into publishing.

## Testing
- `tests/reports/` unit tests green (selections, game_cards, explorer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)