### PR TITLE
feat(scoring): sample_status and training_cutoff_year on every prediction

### DIFF
--- a/docs/plans/2026-07-30-universal-scoring-and-sample-status.md
+++ b/docs/plans/2026-07-30-universal-scoring-and-sample-status.md
@@ -6,90 +6,57 @@
 
 ## Goal & success criteria
 
-Every scoreable game (~128k, gated by description embeddings) carries a current prediction,
-and every prediction row states whether it is a forecast or a fitted value.
+The ~30k rated games get scored, and every prediction row says whether it is a forecast or a
+fitted value.
 
 Done when:
 
 1. `predictions.bgg_predictions` has `sample_status` (STRING) and `training_cutoff_year`
    (INT64) populated for every row.
-2. Both are derived from the registration of the model the scorer actually loaded, never from
+2. Both derive from the registration of the model the scorer actually loaded, never from
    `config.yaml`.
-3. Distinct `game_id` count in `bgg_predictions` is ~128k, not ~17k.
+3. Rated games have predictions; `bgg_predictions` goes from ~17k to ~47k rows.
 4. `sample_status` splits at exactly `year_published <= 2024`.
 
-## Decisions (closed)
+## Settled
 
 | | |
 |---|---|
-| `in_sample` means | `year_published <= test_through` — the year the shipped model was refit through |
-| The value today | **2024** (not 2025 — see below) |
-| `sample_status` values | binary `in_sample` / `out_of_sample`, STRING-typed for later extension |
-| Full-population run | batched, existing endpoint, wider window passed explicitly; request defaults unchanged |
+| Scoring target | upcoming (already done) + rated (`users_rated >= 25`, ~30k) |
+| `in_sample` means | `year_published <= test_through` = **2024** |
+| `sample_status` | binary `in_sample` / `out_of_sample`, STRING-typed |
+| Run mode | existing loop, existing batch size — ~40 min, no parallelism needed |
 
-## What reading the code and the artifact changed
+## Established by measurement
 
-1. **The cutoff is already in the registration.** Verified against the deployed blob
-   `gs://bgg-predictive-models/prod/models/registered/hurdle/hurdle-v2026/v3/registration.json`
-   — `original_experiment.metadata` carries `train_through: 2022`, `tune_through: 2023`,
-   `test_through: 2024`. Models are refit through the test year, so **`test_through` is the
-   training cutoff**. The scorer already loads this dict (it reads `original_experiment.name`
-   from it for every row), so no plumbing is needed — this is a read, not a migration.
+- **The cutoff is in the registration already.** All five deployed models report
+  `train_through: 2022, tune_through: 2023, test_through: 2024` under
+  `original_experiment.metadata` — a dict the scorer already loads. Nothing to plumb.
+  `config.yaml`'s `finalize_through: 2025` is read by no game-model code.
+- **`/simulate_games` is the prod path**, not `/predict_games`. They are not two speeds of the
+  same thing: simulate writes the posterior **median** plus 8 interval columns; predict writes
+  `pipeline.predict()`, rounds `users_rated` to the nearest 50, and clips `geek_rating` to
+  [1,10]. Every existing row came from simulate, so the backfill must use simulate too.
+  `predict_games` is referenced by no workflow.
+- **Cost: ~77ms/game, ~4s fixed per request.** 250 games in 23s, 2,000 in 157s, 6,000 in 673s.
+  Per-game cost rises slightly with batch size, so there is no gain from larger batches.
+- **The 12,018 games with no embedding** all lack `year_published` and are deliberately
+  excluded. Not a backlog.
 
-2. **The number is 2024, not 2025.** `config.yaml`'s `finalize_through: 2025` is read by no
-   game-model code; the only `.py` hits are in `services/collections/`, a separate system.
-   `finalize_model.load_data` independently clamps to `current_year - recent_year_threshold`
-   = 2024, which agrees with the artifact. Anything that hardcoded 2025 is off by a year.
-
-3. **The production write path is `/simulate_games`, not `/predict_games`.**
-   [`run-scoring-service.yml:108`](../../.github/workflows/run-scoring-service.yml#L108) posts
-   to `/simulate_games` with `use_change_detection: true`. Both endpoints call
-   `upload_predictions`, so **both** must emit the new fields — but only simulate feeds the
-   scheduled runs.
-
-4. **Batching already exists and already drains.**
-   `load_changed_games_with_embeddings` ([`loader.py:410-444`](../../src/data/loader.py#L410-L444))
-   selects games that are unscored OR feature-hash-stale OR version-mismatched, `LIMIT
-   max_games`. Scored games leave the set, so looping until `games_simulated == 0` walks the
-   whole population. The workflow already loops; it caps at `MAX_BATCHES=10`. Decision 3 is a
-   `start_year` and a batch-cap change — no new endpoint, no new code.
-
-## Affected files/systems
+## Affected files
 
 **bgg-predictive-models**
-- `services/scoring/main.py` — resolve cutoff from registration, compute status, emit in both endpoints
+- `services/scoring/main.py` — resolve cutoff from registration, compute status, emit it
 - `src/data/bigquery_uploader.py` — pass the two columns through
+- `src/data/loader.py` — ratings predicate for the backfill selection
 - `terraform/bigquery.tf` — two columns on `ml_predictions_landing`
-- `.github/workflows/run-scoring-service.yml` — batch cap + wide-window inputs
-- `tests/` — new unit tests
+- `tests/`
 
 **bgg-data-warehouse**
 - `definitions/bgg_predictions.sqlx` — two columns in `source_data`
-- `definitions/game_first_prediction.sqlx` — only if the `is_new` decision needs it
 
-No change needed: `definitions/sources.js` (declarations carry no schema) and
-`definitions/game_profile.sqlx` (whole-row struct `IF(p.game_id IS NULL, NULL, p)` at
-[line 99](../../../bgg-data-warehouse/definitions/game_profile.sqlx#L99) picks up new columns
-automatically — the viewer's game profile gets the flag for free).
-
----
-
-## Phase 0 — Confirm before writing code
-
-**0.1 — ~~Confirm all five registrations agree.~~ Done.** All five deployed models report
-`train_through: 2022, tune_through: 2023, test_through: 2024` — `hurdle` v3, `complexity` v3,
-`rating` v3, `users_rated` v3, `geek_rating` v2. The single-flag assumption holds, and the
-cutoff is unambiguously **2024**.
-
-**0.2 — Confirm the embeddings ceiling.** Count `games_features` rows with no row in
-`predictions.bgg_description_embeddings`, split by `year_published`, to confirm ~128k is the
-real ceiling and the remainder are genuinely unembedded rather than not-yet-embedded.
-*Verify:* dry-run first, then the counts.
-
-**0.3 — Time one batch.** Run the existing workflow once with `start_year=2020`,
-`max_games=5000`; record wall-clock and Cloud Run memory.
-*Verify:* extrapolate to 128k before committing to Phase 2. If a 5k batch approaches the
-`--max-time 1800` ceiling, lower the batch size rather than raise the timeout.
+No change: `definitions/sources.js` (declarations carry no schema); `game_profile.sqlx` picks up
+new columns automatically via its whole-row struct.
 
 ---
 
@@ -97,46 +64,42 @@ real ceiling and the remainder are genuinely unembedded rather than not-yet-embe
 
 *Branch:* `feat/sample-status-scoring` → PR to `main`.
 
-**1.1 — Resolve the cutoff.** A helper takes the five loaded registrations and returns
-`original_experiment.metadata["test_through"]`. Raise if the key is absent — no `config.yaml`
-fallback, by design. If the five disagree, take the **minimum** and log a warning (min is the
-conservative "seen by every model" boundary).
-*Verify:* unit tests for agreement, disagreement, and missing key.
+**1.1** Helper returning `original_experiment.metadata["test_through"]` from the loaded
+registrations. Raise if absent — no `config.yaml` fallback. If the five disagree, take the
+minimum and log a warning.
+*Verify:* unit tests for agreement, disagreement, missing key.
 
-**1.2 — Compute the status.** `in_sample` when `year_published <= cutoff`, `out_of_sample`
-above it, `unknown` when `year_published` is NULL. (`load_game_data` does not filter NULL years
-the way the change-detection query does, so NULL is reachable and must not silently become
-`out_of_sample`.)
-*Verify:* unit test on the boundary — 2024 → `in_sample`, 2025 → `out_of_sample`, NULL →
-`unknown`.
+**1.2** `in_sample` when `year_published <= cutoff`, else `out_of_sample`. Strictly binary —
+null-year games are never scored.
+*Verify:* unit test on the boundary — 2024 → `in_sample`, 2025 → `out_of_sample`.
 
-**1.3 — Emit from both endpoints.** Add both columns to the `dw_predictions` selection in
-`predict_games` ([`main.py:728-739`](../../services/scoring/main.py#L728-L739)) and to
-`flat_rows` in `simulate_games` ([`main.py:1184-1201`](../../services/scoring/main.py#L1184-L1201)).
+**1.3** Emit from `simulate_games` (`flat_rows`, [`main.py:1184`](../../services/scoring/main.py#L1184))
+and from `predict_games` (`dw_predictions`, [`main.py:728`](../../services/scoring/main.py#L728))
+so the two paths cannot diverge, even though only simulate runs in prod.
 *Verify:* a `game_ids` request against a local run returns both fields.
 
-**1.4 — Terraform.** Add `sample_status` (STRING, NULLABLE) and `training_cutoff_year`
-(INTEGER, NULLABLE) to `ml_predictions_landing`. The uploader already sets
-`ALLOW_FIELD_ADDITION`, so a load could add them implicitly — declare them in terraform anyway
-so state does not drift, matching the 2026-02-05 interval-columns precedent.
+**1.4** Terraform: `sample_status` (STRING, NULLABLE) and `training_cutoff_year` (INTEGER,
+NULLABLE) on `ml_predictions_landing`.
 *Verify:* `terraform plan` shows only the two field additions.
 
 Deploy via the Cloud Build workflow after merge.
 
 ---
 
-## Phase 2 — Full-population backfill
+## Phase 2 — Score the rated games
 
-**Runs before the Dataform change, deliberately** — so a single full refresh absorbs both the
-new columns and the 110k new games instead of two.
+Runs **before** the Dataform change, so one full refresh absorbs both the new columns and the
+new rows.
 
-**2.1** Raise `MAX_BATCHES` (128k ÷ batch size, plus headroom) and let `start_year` accept a low
-floor. Keep the `2025` workflow default and the `2024` request-model default untouched.
-*Verify:* the diff touches only the input plumbing and the cap.
+**2.1** The change-detection query
+([`loader.py:410-444`](../../src/data/loader.py#L410-L444)) filters on year and staleness only
+— it has no ratings predicate. Add one so the backfill targets rated games rather than
+everything with an embedding.
+*Verify:* the selection query returns ~30k before any scoring runs.
 
-**2.2** Run with `start_year=1900` and the batch size from 0.3, monitoring per-batch timing.
-*Verify:* `SELECT COUNT(DISTINCT game_id) FROM raw.ml_predictions_landing` → ~128k;
-`sample_status` splits at 2024; no NULL `training_cutoff_year`.
+**2.2** Run the existing workflow with a wide `start_year`. ~40 minutes at current batch size.
+*Verify:* `COUNT(DISTINCT game_id)` in the landing table → ~47k; `sample_status` splits at
+2024; no NULL `training_cutoff_year`.
 
 ---
 
@@ -148,47 +111,35 @@ floor. Keep the `2025` workflow default and the `2024` request-model default unt
 *Verify:* Dataform compile **plus a `CREATE TABLE` dry-run** — a bare `SELECT` dry-run misses
 `ref()` and duplicate-field errors.
 
-**3.2** Merge, then immediately full-refresh `bgg_predictions` via the Dataform API (targeted
-refresh needs the `database` field in the target). Do not let an ordinary scheduled run hit the
-merged model first — Dataform will not `ALTER` the existing incremental table.
-*Verify before:* record `COUNT(*)`, `COUNT(DISTINCT game_id)`, `MIN/MAX(first_prediction_ts)`.
-*After:* ~128k rows, both columns non-NULL, and `first_prediction_ts` for pre-existing games
-**unchanged** — it derives from `MIN(score_ts)` over the append-only landing table
-([`game_first_prediction.sqlx:9`](../../../bgg-data-warehouse/definitions/game_first_prediction.sqlx#L9)),
-so a refresh cannot reset it.
+**3.2** Merge, then immediately full-refresh `bgg_predictions` via the Dataform API. Do not let
+an ordinary scheduled run hit the merged model first — Dataform will not `ALTER` the existing
+incremental table.
+*Verify before:* `COUNT(*)`, `COUNT(DISTINCT game_id)`, `MIN/MAX(first_prediction_ts)`.
+*After:* ~47k rows, both columns non-NULL, `first_prediction_ts` unchanged for pre-existing
+games — it derives from `MIN(score_ts)` over the append-only landing table, so a refresh
+cannot reset it.
 
 ---
 
-## Phase 4 — The `is_new` stampede
+## Open
 
-110k games get their first `score_ts` on backfill day, so `is_new_1d` / `is_new_7d` go true for
-all of them at once. Existing games are unaffected (their `MIN(score_ts)` is historical).
+**The `is_new` stampede.** ~30k games get the same `first_prediction_ts`. Consumers found so
+far are in this repo's reports — [`predictions_report.qmd:82`](../../reports/predictions_report.qmd#L82)
+(already scoped to `upcoming`, so likely unaffected) and
+[`collection_data.py:431`](../../src/reports/collection_data.py#L431) (computes its own flag
+from `first_score_ts`). bgg-viewer and bgg-dash-viewer not yet checked. Verify the consumers
+before deciding whether any mitigation is needed.
 
-**Recommendation:** exclude the backfill date explicitly in `bgg_predictions.sqlx` —
-`AND DATE(fp.first_prediction_ts) != DATE('<backfill-date>')` on the `is_new_*` expressions,
-with a comment naming the backfill. Blunt but auditable and removable, and it keeps "new on
-BGG" meaningful in the week after. The alternative is to accept one noisy week.
-
-**This is the one item still open.**
-
----
-
-## Risks / unknowns / rollback
+## Risks
 
 | Risk | Handling |
 |---|---|
-| **Full refresh of `bgg_predictions`** — the only irreversible-ish step | Rebuildable from the append-only landing table; take before/after counts |
-| **In-sample predictions flatter aggregate quality metrics** | Any aggregate over `bgg_predictions` must filter `sample_status`; note it wherever such figures are computed |
-| **Memory on a large batch** — the loader materialises embeddings into pandas | Batch size set from the 0.3 measurement, not guessed |
-| **Cloud Run 1800s per-batch ceiling** | Lower batch size rather than raise the timeout |
-| **Unknown:** whether all five models share `test_through: 2024` | Phase 0.1, before any code |
-
-Cost is not a factor: ~44 MB at 128k rows, ~$0.0009/month storage.
+| **Full refresh of `bgg_predictions`** | Rebuildable from the append-only landing table; take before/after counts |
+| **In-sample predictions flatter aggregate metrics** | Any aggregate must filter `sample_status` |
 
 ## Out of scope
 
-- Feature-hash-triggered incremental rescoring (deferred by the spec).
+- Feature-hash-triggered incremental rescoring.
 - Retraining, split changes, model selection.
-- Any bgg-viewer UI, including the Predictions view.
+- bgg-viewer UI.
 - Prediction history — `bgg_predictions` stays one latest row per game.
-- The hurdle threshold discrepancy noted while reading the registration — separate issue.

--- a/docs/plans/2026-07-30-universal-scoring-and-sample-status.md
+++ b/docs/plans/2026-07-30-universal-scoring-and-sample-status.md
@@ -1,0 +1,194 @@
+# Universal Scoring and Sample Status — Implementation Plan
+
+**Date:** 2026-07-30
+**Spec:** [2026-07-30-universal-scoring-and-sample-status-design.md](../specs/2026-07-30-universal-scoring-and-sample-status-design.md)
+**Status:** Awaiting approval
+
+## Goal & success criteria
+
+Every scoreable game (~128k, gated by description embeddings) carries a current prediction,
+and every prediction row states whether it is a forecast or a fitted value.
+
+Done when:
+
+1. `predictions.bgg_predictions` has `sample_status` (STRING) and `training_cutoff_year`
+   (INT64) populated for every row.
+2. Both are derived from the registration of the model the scorer actually loaded, never from
+   `config.yaml`.
+3. Distinct `game_id` count in `bgg_predictions` is ~128k, not ~17k.
+4. `sample_status` splits at exactly `year_published <= 2024`.
+
+## Decisions (closed)
+
+| | |
+|---|---|
+| `in_sample` means | `year_published <= test_through` — the year the shipped model was refit through |
+| The value today | **2024** (not 2025 — see below) |
+| `sample_status` values | binary `in_sample` / `out_of_sample`, STRING-typed for later extension |
+| Full-population run | batched, existing endpoint, wider window passed explicitly; request defaults unchanged |
+
+## What reading the code and the artifact changed
+
+1. **The cutoff is already in the registration.** Verified against the deployed blob
+   `gs://bgg-predictive-models/prod/models/registered/hurdle/hurdle-v2026/v3/registration.json`
+   — `original_experiment.metadata` carries `train_through: 2022`, `tune_through: 2023`,
+   `test_through: 2024`. Models are refit through the test year, so **`test_through` is the
+   training cutoff**. The scorer already loads this dict (it reads `original_experiment.name`
+   from it for every row), so no plumbing is needed — this is a read, not a migration.
+
+2. **The number is 2024, not 2025.** `config.yaml`'s `finalize_through: 2025` is read by no
+   game-model code; the only `.py` hits are in `services/collections/`, a separate system.
+   `finalize_model.load_data` independently clamps to `current_year - recent_year_threshold`
+   = 2024, which agrees with the artifact. Anything that hardcoded 2025 is off by a year.
+
+3. **The production write path is `/simulate_games`, not `/predict_games`.**
+   [`run-scoring-service.yml:108`](../../.github/workflows/run-scoring-service.yml#L108) posts
+   to `/simulate_games` with `use_change_detection: true`. Both endpoints call
+   `upload_predictions`, so **both** must emit the new fields — but only simulate feeds the
+   scheduled runs.
+
+4. **Batching already exists and already drains.**
+   `load_changed_games_with_embeddings` ([`loader.py:410-444`](../../src/data/loader.py#L410-L444))
+   selects games that are unscored OR feature-hash-stale OR version-mismatched, `LIMIT
+   max_games`. Scored games leave the set, so looping until `games_simulated == 0` walks the
+   whole population. The workflow already loops; it caps at `MAX_BATCHES=10`. Decision 3 is a
+   `start_year` and a batch-cap change — no new endpoint, no new code.
+
+## Affected files/systems
+
+**bgg-predictive-models**
+- `services/scoring/main.py` — resolve cutoff from registration, compute status, emit in both endpoints
+- `src/data/bigquery_uploader.py` — pass the two columns through
+- `terraform/bigquery.tf` — two columns on `ml_predictions_landing`
+- `.github/workflows/run-scoring-service.yml` — batch cap + wide-window inputs
+- `tests/` — new unit tests
+
+**bgg-data-warehouse**
+- `definitions/bgg_predictions.sqlx` — two columns in `source_data`
+- `definitions/game_first_prediction.sqlx` — only if the `is_new` decision needs it
+
+No change needed: `definitions/sources.js` (declarations carry no schema) and
+`definitions/game_profile.sqlx` (whole-row struct `IF(p.game_id IS NULL, NULL, p)` at
+[line 99](../../../bgg-data-warehouse/definitions/game_profile.sqlx#L99) picks up new columns
+automatically — the viewer's game profile gets the flag for free).
+
+---
+
+## Phase 0 — Confirm before writing code
+
+**0.1 — ~~Confirm all five registrations agree.~~ Done.** All five deployed models report
+`train_through: 2022, tune_through: 2023, test_through: 2024` — `hurdle` v3, `complexity` v3,
+`rating` v3, `users_rated` v3, `geek_rating` v2. The single-flag assumption holds, and the
+cutoff is unambiguously **2024**.
+
+**0.2 — Confirm the embeddings ceiling.** Count `games_features` rows with no row in
+`predictions.bgg_description_embeddings`, split by `year_published`, to confirm ~128k is the
+real ceiling and the remainder are genuinely unembedded rather than not-yet-embedded.
+*Verify:* dry-run first, then the counts.
+
+**0.3 — Time one batch.** Run the existing workflow once with `start_year=2020`,
+`max_games=5000`; record wall-clock and Cloud Run memory.
+*Verify:* extrapolate to 128k before committing to Phase 2. If a 5k batch approaches the
+`--max-time 1800` ceiling, lower the batch size rather than raise the timeout.
+
+---
+
+## Phase 1 — Emit `sample_status` and `training_cutoff_year`
+
+*Branch:* `feat/sample-status-scoring` → PR to `main`.
+
+**1.1 — Resolve the cutoff.** A helper takes the five loaded registrations and returns
+`original_experiment.metadata["test_through"]`. Raise if the key is absent — no `config.yaml`
+fallback, by design. If the five disagree, take the **minimum** and log a warning (min is the
+conservative "seen by every model" boundary).
+*Verify:* unit tests for agreement, disagreement, and missing key.
+
+**1.2 — Compute the status.** `in_sample` when `year_published <= cutoff`, `out_of_sample`
+above it, `unknown` when `year_published` is NULL. (`load_game_data` does not filter NULL years
+the way the change-detection query does, so NULL is reachable and must not silently become
+`out_of_sample`.)
+*Verify:* unit test on the boundary — 2024 → `in_sample`, 2025 → `out_of_sample`, NULL →
+`unknown`.
+
+**1.3 — Emit from both endpoints.** Add both columns to the `dw_predictions` selection in
+`predict_games` ([`main.py:728-739`](../../services/scoring/main.py#L728-L739)) and to
+`flat_rows` in `simulate_games` ([`main.py:1184-1201`](../../services/scoring/main.py#L1184-L1201)).
+*Verify:* a `game_ids` request against a local run returns both fields.
+
+**1.4 — Terraform.** Add `sample_status` (STRING, NULLABLE) and `training_cutoff_year`
+(INTEGER, NULLABLE) to `ml_predictions_landing`. The uploader already sets
+`ALLOW_FIELD_ADDITION`, so a load could add them implicitly — declare them in terraform anyway
+so state does not drift, matching the 2026-02-05 interval-columns precedent.
+*Verify:* `terraform plan` shows only the two field additions.
+
+Deploy via the Cloud Build workflow after merge.
+
+---
+
+## Phase 2 — Full-population backfill
+
+**Runs before the Dataform change, deliberately** — so a single full refresh absorbs both the
+new columns and the 110k new games instead of two.
+
+**2.1** Raise `MAX_BATCHES` (128k ÷ batch size, plus headroom) and let `start_year` accept a low
+floor. Keep the `2025` workflow default and the `2024` request-model default untouched.
+*Verify:* the diff touches only the input plumbing and the cap.
+
+**2.2** Run with `start_year=1900` and the batch size from 0.3, monitoring per-batch timing.
+*Verify:* `SELECT COUNT(DISTINCT game_id) FROM raw.ml_predictions_landing` → ~128k;
+`sample_status` splits at 2024; no NULL `training_cutoff_year`.
+
+---
+
+## Phase 3 — Warehouse plumbing
+
+*Branch in bgg-data-warehouse:* `feat/prediction-sample-status` → PR to `main`.
+
+**3.1** Add both columns to the `source_data` select in `bgg_predictions.sqlx`.
+*Verify:* Dataform compile **plus a `CREATE TABLE` dry-run** — a bare `SELECT` dry-run misses
+`ref()` and duplicate-field errors.
+
+**3.2** Merge, then immediately full-refresh `bgg_predictions` via the Dataform API (targeted
+refresh needs the `database` field in the target). Do not let an ordinary scheduled run hit the
+merged model first — Dataform will not `ALTER` the existing incremental table.
+*Verify before:* record `COUNT(*)`, `COUNT(DISTINCT game_id)`, `MIN/MAX(first_prediction_ts)`.
+*After:* ~128k rows, both columns non-NULL, and `first_prediction_ts` for pre-existing games
+**unchanged** — it derives from `MIN(score_ts)` over the append-only landing table
+([`game_first_prediction.sqlx:9`](../../../bgg-data-warehouse/definitions/game_first_prediction.sqlx#L9)),
+so a refresh cannot reset it.
+
+---
+
+## Phase 4 — The `is_new` stampede
+
+110k games get their first `score_ts` on backfill day, so `is_new_1d` / `is_new_7d` go true for
+all of them at once. Existing games are unaffected (their `MIN(score_ts)` is historical).
+
+**Recommendation:** exclude the backfill date explicitly in `bgg_predictions.sqlx` —
+`AND DATE(fp.first_prediction_ts) != DATE('<backfill-date>')` on the `is_new_*` expressions,
+with a comment naming the backfill. Blunt but auditable and removable, and it keeps "new on
+BGG" meaningful in the week after. The alternative is to accept one noisy week.
+
+**This is the one item still open.**
+
+---
+
+## Risks / unknowns / rollback
+
+| Risk | Handling |
+|---|---|
+| **Full refresh of `bgg_predictions`** — the only irreversible-ish step | Rebuildable from the append-only landing table; take before/after counts |
+| **In-sample predictions flatter aggregate quality metrics** | Any aggregate over `bgg_predictions` must filter `sample_status`; note it wherever such figures are computed |
+| **Memory on a large batch** — the loader materialises embeddings into pandas | Batch size set from the 0.3 measurement, not guessed |
+| **Cloud Run 1800s per-batch ceiling** | Lower batch size rather than raise the timeout |
+| **Unknown:** whether all five models share `test_through: 2024` | Phase 0.1, before any code |
+
+Cost is not a factor: ~44 MB at 128k rows, ~$0.0009/month storage.
+
+## Out of scope
+
+- Feature-hash-triggered incremental rescoring (deferred by the spec).
+- Retraining, split changes, model selection.
+- Any bgg-viewer UI, including the Predictions view.
+- Prediction history — `bgg_predictions` stays one latest row per game.
+- The hurdle threshold discrepancy noted while reading the registration — separate issue.

--- a/docs/specs/2026-07-30-universal-scoring-and-sample-status-design.md
+++ b/docs/specs/2026-07-30-universal-scoring-and-sample-status-design.md
@@ -1,0 +1,180 @@
+# Universal Scoring and Sample Status Design
+
+**Date:** 2026-07-30
+**Status:** Draft — decisions marked below need Phil's call before an implementation plan
+
+## Goal
+
+Every game in the data warehouse carries a current prediction from the active deployed
+models, and every prediction says whether it is a **forecast** or a **fitted value** — a
+score for a game the model was trained on.
+
+Two consumers depend on this:
+
+- **bgg-viewer game profile** — shows the prediction for any game, labelled with its status.
+  Phil wants in-sample predictions visible precisely *because* they show model behaviour;
+  they must be labelled, not hidden.
+- **bgg-viewer catalog artifact** — already carries the five predicted columns for every game
+  in its working set. It needs the status flag to travel with them.
+
+## Non-goals
+
+- **Feature-hash-triggered rescoring.** Agreed to defer: backfill first, incremental
+  rescoring as its own piece. This spec must not make that harder, but does not build it.
+- Retraining, changing the splits, or touching model selection.
+- Any bgg-viewer UI. The Predictions view is a separate design.
+- Backfilling prediction *history*. `bgg_predictions` stays one latest row per game;
+  `ml_predictions_landing` keeps the append-only record.
+
+## Current state
+
+Measured 2026-07-30, not assumed:
+
+| Fact | Value |
+|---|---|
+| `raw.ml_predictions_landing` | 17,067 distinct games, `year_published` 2024–2028, 252 jobs |
+| `predictions.bgg_predictions` | 17,067 rows, 5,864,858 bytes (**344 bytes/row**) |
+| Games with embeddings + complexity | **127,940** — the real scoreable ceiling |
+| bgg-viewer catalog working set | 35,263 games; 7,424 currently have a prediction |
+
+**The year gate is not in the warehouse.** [`definitions/bgg_predictions.sqlx`](../../../bgg-data-warehouse/definitions/bgg_predictions.sqlx)
+has no year filter — it takes the latest row per `game_id` from the landing table. The
+17,067-game limit comes entirely from the scoring service:
+
+- `start_year: Optional[int] = 2024` — request-model defaults, [`services/scoring/main.py:91`](../../services/scoring/main.py#L91) and [`:124`](../../services/scoring/main.py#L124)
+- the filter is only appended when set, [`services/scoring/main.py:292`](../../services/scoring/main.py#L292):
+  ```python
+  if start_year is not None:
+      where_parts.append(f"f.year_published >= {start_year}")
+  ```
+- `game_ids` takes precedence over year filtering entirely ([`main.py:287`](../../services/scoring/main.py#L287))
+- `load_games_for_main_scoring(..., max_games: int = 50000)` ([`main.py:305`](../../services/scoring/main.py#L305))
+
+So scoring the full population is a **payload and cap change, not a new capability**.
+
+**Sample status is a property of the model, not the game.** From `config.yaml`:
+
+```yaml
+years:
+  training:
+    train_through: 2022
+    tune_start: 2023 / tune_through: 2023
+    test_start: 2024 / test_through: 2024
+finalize_through: 2025   # finalize() refits on train+val+test filtered to <= this
+```
+
+The shipped pipeline is refit through 2025, so it has seen essentially every game published
+through 2025. A prediction for a pre-2026 game is in-sample. Critically, `finalize_through`
+moves when the model is refit — which is why this cannot be derived downstream.
+
+## The gap
+
+1. **Coverage.** 17,067 of ~127,940 scoreable games are scored.
+2. **No status field.** `bgg_predictions` columns are `job_id, game_id, name, year_published,
+   predicted_*, {target}_model_{name,version,experiment}, score_ts, source_environment,
+   first_prediction_ts, is_new_1d, is_new_7d`. Nothing distinguishes a forecast from a fitted
+   value.
+
+Consumers today can only infer status by hardcoding "2025", which silently goes wrong at the
+next refit. That is the reason this belongs in the pipeline.
+
+## Design
+
+### 1. Scoring population
+
+Score every game that *can* be scored: has description embeddings and a complexity value.
+That is ~127,940, not the ~140k total, because the models take `emb_0..emb_N` as features and
+a game without an embedding cannot be scored at all.
+
+Two changes:
+
+- Drive the scoring run with `start_year=None` (or an explicit floor) rather than the 2024
+  default. The request model's default stays 2024 so existing scheduled runs are unaffected;
+  the full run passes the wider window explicitly.
+- Raise or remove `max_games`. At 50,000 it silently truncates a 128k run. **Recommend
+  batching** rather than one 128k call — the loader pulls embeddings into a pandas frame, and
+  a single frame of 128k × 64 embedding columns plus features is a memory risk worth avoiding.
+
+**Decision needed:** batch size and whether the full run is a separate endpoint/mode or the
+same one with a wider window.
+
+### 2. Sample status on the prediction row
+
+Emit two new fields per prediction, from the scorer, which knows which model it loaded:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `sample_status` | STRING | `in_sample` / `out_of_sample` |
+| `training_cutoff_year` | INT64 | the `finalize_through` the scoring pipeline was fitted with |
+
+`sample_status` is what consumers read. `training_cutoff_year` is what makes it auditable and
+keeps it honest across refits — if the flag and the cutoff ever disagree, that is a visible
+bug rather than a silent one.
+
+**Why a string and not a boolean:** the config has real `train` / `tune` / `test` /
+post-finalize distinctions, and a boolean forecloses ever exposing them. A string costs
+nothing and can gain values later without a schema change.
+
+**Why one flag and not five:** each target has its own model and version, so in principle a
+game could be in-sample for `hurdle` and not for `complexity`. Today they share one
+`finalize_through`, so one flag is correct. If the targets ever diverge, `training_cutoff_year`
+is the field that would need to go per-target — flagged here so that is a deliberate choice
+later, not a surprise.
+
+**Decision needed:** confirm `in_sample` should be relative to `finalize_through` (what the
+shipped model actually saw) rather than `train_through` (the narrower training split). These
+differ for 2023–2025 games, which is a large and interesting population.
+
+### 3. Warehouse plumbing
+
+`bgg_predictions.sqlx` selects columns explicitly, so the two new fields must be added to its
+`source_data` select. **This is a schema change on an `incremental` table — Dataform will not
+`ALTER` an existing table, so the deploy requires a full refresh**, not an ordinary run.
+
+Storage is not a consideration at this scale:
+
+| | |
+|---|---|
+| Today | 17,067 rows, 5.86 MB |
+| At ~128k rows | **~44 MB** |
+| Storage | ~**$0.0009 / month** |
+| Full scan | ~**$0.0003** |
+
+The per-game read already pays BigQuery's 10 MB minimum, so the point lookup barely moves.
+
+### 4. Downstream, for reference
+
+bgg-viewer's catalog artifact already carries the five predicted columns (+128 KB gzipped,
++2.9%). Once `sample_status` exists it joins them, and the game profile can label a fitted
+value as such. No viewer change is in scope here.
+
+## Risks and one-way doors
+
+- **The full refresh of `bgg_predictions`** is the only irreversible-ish step. It rebuilds
+  from `ml_predictions_landing`, which is append-only and retains everything, so the table can
+  be reconstructed — but `first_prediction_ts` derives from `game_first_prediction` and should
+  be checked before and after so "new game" flags do not all reset.
+- **Scoring 128k games in-sample will produce flattering numbers.** That is the point — they
+  are labelled — but any aggregate model-quality figure computed over `bgg_predictions`
+  without filtering on `sample_status` will be wrong. Worth a note wherever such aggregates
+  are computed.
+- **`is_new_1d` / `is_new_7d`** are computed from `first_prediction_ts`. A one-off backfill of
+  110k games gives them all a first prediction on the same day; anything keying off "new"
+  should be checked against that.
+
+## Validation before implementing
+
+1. Confirm the embeddings join is really the ceiling — count games in `games_features` with no
+   description embedding, and confirm they are genuinely unscoreable rather than merely
+   unembedded-so-far.
+2. Time a scoring run over a single batch (say 10k games) to get a per-game cost, then
+   extrapolate to 128k before committing to a full run.
+3. Confirm `finalize_through` is readable at scoring time from the loaded model/registry
+   rather than only from `config.yaml` — if the scorer has to read the config, the flag can
+   drift from the model actually loaded, which defeats the purpose.
+
+## Open decisions
+
+1. Batch size / run mode for the full-population score.
+2. `in_sample` relative to `finalize_through` (recommended) or `train_through`.
+3. Whether `sample_status` should carry the finer `train`/`tune`/`test` values now or later.

--- a/docs/specs/2026-07-30-universal-scoring-and-sample-status-design.md
+++ b/docs/specs/2026-07-30-universal-scoring-and-sample-status-design.md
@@ -34,8 +34,17 @@ Measured 2026-07-30, not assumed:
 |---|---|
 | `raw.ml_predictions_landing` | 17,067 distinct games, `year_published` 2024–2028, 252 jobs |
 | `predictions.bgg_predictions` | 17,067 rows, 5,864,858 bytes (**344 bytes/row**) |
-| Games with embeddings + complexity | **127,940** — the real scoreable ceiling |
+| Games with an embedding | 127,949 (the other 12,018 have no `year_published` and are deliberately not scored) |
 | bgg-viewer catalog working set | 35,263 games; 7,424 currently have a prediction |
+
+**The scoring target is not every embedded game.** Two sets get scored:
+
+- **all upcoming games**, no ratings filter — *already scored*; these are the 17,067
+- **all rated games**, ~30k
+
+Everything else — old games with too few ratings to matter — is deliberately left unscored.
+So the coverage gap is **~30k rated games, not ~110k**. At a measured ~77ms/game this is
+roughly 40 minutes in the existing batch loop, which makes run mode a non-question.
 
 **The year gate is not in the warehouse.** [`definitions/bgg_predictions.sqlx`](../../../bgg-data-warehouse/definitions/bgg_predictions.sqlx)
 has no year filter — it takes the latest row per `game_id` from the landing table. The
@@ -76,7 +85,7 @@ config.
 
 ## The gap
 
-1. **Coverage.** 17,067 of ~127,940 scoreable games are scored.
+1. **Coverage.** Upcoming games are scored; the ~30k rated games are not.
 2. **No status field.** `bgg_predictions` columns are `job_id, game_id, name, year_published,
    predicted_*, {target}_model_{name,version,experiment}, score_ts, source_environment,
    first_prediction_ts, is_new_1d, is_new_7d`. Nothing distinguishes a forecast from a fitted
@@ -89,21 +98,20 @@ next refit. That is the reason this belongs in the pipeline.
 
 ### 1. Scoring population
 
-Score every game that *can* be scored: has description embeddings and a complexity value.
-That is ~127,940, not the ~140k total, because the models take `emb_0..emb_N` as features and
-a game without an embedding cannot be scored at all.
+Upcoming + rated. Upcoming is already covered, so the work is the **~30k rated games**
+(`users_rated >= 25`, matching the `hurdle` definition in `games_features`).
 
-Two changes:
+One change: drive the run with a wide `start_year` so the change-detection loop reaches rated
+games from earlier years. The request model's default stays 2024 so scheduled runs are
+unaffected; the backfill passes the wider window explicitly.
 
-- Drive the scoring run with `start_year=None` (or an explicit floor) rather than the 2024
-  default. The request model's default stays 2024 so existing scheduled runs are unaffected;
-  the full run passes the wider window explicitly.
-- Raise or remove `max_games`. At 50,000 it silently truncates a 128k run. **Recommend
-  batching** rather than one 128k call — the loader pulls embeddings into a pandas frame, and
-  a single frame of 128k × 64 embedding columns plus features is a memory risk worth avoiding.
+`max_games` at 50,000 does not truncate a ~30k run, and the existing while-loop in
+`run-scoring-service.yml` already drains the change-detection set. **No new endpoint, no
+parallelism, no batch-size tuning** — measured at ~77ms/game, ~30k is roughly 40 minutes.
 
-**Decision needed:** batch size and whether the full run is a separate endpoint/mode or the
-same one with a wider window.
+Note that the loader's change-detection query has no ratings filter — it selects on year and
+staleness only. Restricting the backfill to rated games needs either a ratings predicate added
+there or the batch driven by `game_ids`.
 
 ### 2. Sample status on the prediction row
 
@@ -143,9 +151,9 @@ Storage is not a consideration at this scale:
 | | |
 |---|---|
 | Today | 17,067 rows, 5.86 MB |
-| At ~128k rows | **~44 MB** |
-| Storage | ~**$0.0009 / month** |
-| Full scan | ~**$0.0003** |
+| At ~47k rows (upcoming + rated) | **~16 MB** |
+| Storage | ~**$0.0003 / month** |
+| Full scan | ~**$0.0001** |
 
 The per-game read already pays BigQuery's 10 MB minimum, so the point lookup barely moves.
 
@@ -161,21 +169,24 @@ value as such. No viewer change is in scope here.
   from `ml_predictions_landing`, which is append-only and retains everything, so the table can
   be reconstructed — but `first_prediction_ts` derives from `game_first_prediction` and should
   be checked before and after so "new game" flags do not all reset.
-- **Scoring 128k games in-sample will produce flattering numbers.** That is the point — they
-  are labelled — but any aggregate model-quality figure computed over `bgg_predictions`
+- **Scoring ~30k rated games in-sample will produce flattering numbers.** That is the point —
+  they are labelled — but any aggregate model-quality figure computed over `bgg_predictions`
   without filtering on `sample_status` will be wrong. Worth a note wherever such aggregates
   are computed.
 - **`is_new_1d` / `is_new_7d`** are computed from `first_prediction_ts`. A one-off backfill of
-  110k games gives them all a first prediction on the same day; anything keying off "new"
-  should be checked against that.
+  ~30k games gives them all a first prediction on the same day; anything keying off "new"
+  should be checked against that. Known consumers are the prediction and collection reports —
+  the predictions report already scopes to `upcoming`, so the exposure may be nil. To be
+  confirmed separately.
 
 ## Validation before implementing
 
-1. Confirm the embeddings join is really the ceiling — count games in `games_features` with no
-   description embedding, and confirm they are genuinely unscoreable rather than merely
-   unembedded-so-far.
-2. Time a scoring run over a single batch (say 10k games) to get a per-game cost, then
-   extrapolate to 128k before committing to a full run.
+1. ~~Confirm the embeddings join is really the ceiling.~~ **Resolved, and moot.** 127,949
+   games have an embedding; the 12,018 without one all lack `year_published` and are
+   deliberately not scored. The scoring target is upcoming + rated, not every embedded game.
+2. ~~Time a scoring run.~~ **Measured:** ~77ms/game, ~4s fixed cost per request (250 games in
+   23s, 2,000 in 157s, 6,000 in 673s — per-game cost rises slightly with batch size). ~30k is
+   roughly 40 minutes in the existing loop.
 3. ~~Confirm the cutoff is readable at scoring time from the loaded model.~~ **Resolved.**
    `original_experiment.metadata.test_through` is in the registration the scorer already
    loads. All five deployed models agree — `train_through: 2022, tune_through: 2023,
@@ -184,8 +195,8 @@ value as such. No viewer change is in scope here.
 
 ## Open decisions
 
-1. ~~Batch size / run mode.~~ Batched against the existing endpoint; the change-detection
-   loop already drains the population. Batch size set from a timed trial.
+1. ~~Batch size / run mode.~~ Moot. The gap is ~30k rated games, ~40 minutes in the existing
+   loop at the existing batch size.
 2. ~~`in_sample` relative to which cutoff.~~ The refit cutoff, `test_through` = 2024.
 3. ~~Finer `train`/`tune`/`test` values.~~ Binary. Once the cutoff is the refit year there is
    one boundary, not three.

--- a/docs/specs/2026-07-30-universal-scoring-and-sample-status-design.md
+++ b/docs/specs/2026-07-30-universal-scoring-and-sample-status-design.md
@@ -52,20 +52,27 @@ has no year filter — it takes the latest row per `game_id` from the landing ta
 
 So scoring the full population is a **payload and cap change, not a new capability**.
 
-**Sample status is a property of the model, not the game.** From `config.yaml`:
+**Sample status is a property of the model, not the game.** The shipped models are refit
+through their **test year**, so `test_through` is the training cutoff.
 
-```yaml
-years:
-  training:
-    train_through: 2022
-    tune_start: 2023 / tune_through: 2023
-    test_start: 2024 / test_through: 2024
-finalize_through: 2025   # finalize() refits on train+val+test filtered to <= this
+Verified against the deployed artifact — `gs://bgg-predictive-models/prod/models/registered/
+hurdle/hurdle-v2026/v3/registration.json`, under `original_experiment.metadata`:
+
+```json
+"train_through": 2022,
+"tune_through":  2023,
+"test_through":  2024,
 ```
 
-The shipped pipeline is refit through 2025, so it has seen essentially every game published
-through 2025. A prediction for a pre-2026 game is in-sample. Critically, `finalize_through`
-moves when the model is refit — which is why this cannot be derived downstream.
+**The cutoff is 2024, not 2025.** `config.yaml`'s `finalize_through: 2025` is read by no
+game-model code — grep it: the only `.py` hits are in `services/collections/`, a separate
+system reading its own value. Independently, `finalize_model.load_data` clamps the end year to
+`current_year - recent_year_threshold` = `2026 - 2` = 2024, which agrees.
+
+The scoring service already loads this dict — it reads `original_experiment.name` from it for
+every prediction row. So the cutoff is available at scoring time with no new plumbing, and it
+moves correctly when the model is refit, which is why it must come from here and not from
+config.
 
 ## The gap
 
@@ -121,9 +128,9 @@ game could be in-sample for `hurdle` and not for `complexity`. Today they share 
 is the field that would need to go per-target — flagged here so that is a deliberate choice
 later, not a surprise.
 
-**Decision needed:** confirm `in_sample` should be relative to `finalize_through` (what the
-shipped model actually saw) rather than `train_through` (the narrower training split). These
-differ for 2023–2025 games, which is a large and interesting population.
+**Decided:** `in_sample` is relative to the refit cutoff — what the shipped model actually saw
+— which is `test_through`, **2024**. Not `train_through` (2022), and not the 2025 this spec
+originally asserted. 2023 and 2024 games are therefore `in_sample`; 2025 games are not.
 
 ### 3. Warehouse plumbing
 
@@ -169,12 +176,17 @@ value as such. No viewer change is in scope here.
    unembedded-so-far.
 2. Time a scoring run over a single batch (say 10k games) to get a per-game cost, then
    extrapolate to 128k before committing to a full run.
-3. Confirm `finalize_through` is readable at scoring time from the loaded model/registry
-   rather than only from `config.yaml` — if the scorer has to read the config, the flag can
-   drift from the model actually loaded, which defeats the purpose.
+3. ~~Confirm the cutoff is readable at scoring time from the loaded model.~~ **Resolved.**
+   `original_experiment.metadata.test_through` is in the registration the scorer already
+   loads. All five deployed models agree — `train_through: 2022, tune_through: 2023,
+   test_through: 2024` (`hurdle` v3, `complexity` v3, `rating` v3, `users_rated` v3,
+   `geek_rating` v2), so the single flag argued for above is correct.
 
 ## Open decisions
 
-1. Batch size / run mode for the full-population score.
-2. `in_sample` relative to `finalize_through` (recommended) or `train_through`.
-3. Whether `sample_status` should carry the finer `train`/`tune`/`test` values now or later.
+1. ~~Batch size / run mode.~~ Batched against the existing endpoint; the change-detection
+   loop already drains the population. Batch size set from a timed trial.
+2. ~~`in_sample` relative to which cutoff.~~ The refit cutoff, `test_through` = 2024.
+3. ~~Finer `train`/`tune`/`test` values.~~ Binary. Once the cutoff is the refit year there is
+   one boundary, not three.
+4. **Open:** how to handle the `is_new_1d` / `is_new_7d` stampede from the backfill.

--- a/services/scoring/main.py
+++ b/services/scoring/main.py
@@ -23,6 +23,10 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, project_root)
 
 from registered_model import RegisteredModel  # noqa: E402
+from sample_status import (  # noqa: E402
+    compute_sample_status,
+    resolve_training_cutoff_year,
+)
 from src.data.loader import BGGDataLoader  # noqa: E402
 from src.utils.config import load_config  # noqa: E402
 from src.data.bigquery_uploader import DataWarehousePredictionUploader  # noqa: E402
@@ -671,6 +675,19 @@ async def predict_games_endpoint(request: PredictGamesRequest):
             "original_experiment"
         ]["name"]
 
+        # Label each row against the cutoff the loaded models were fitted through
+        training_cutoff_year = resolve_training_cutoff_year({
+            "hurdle": hurdle_registration,
+            "complexity": complexity_registration,
+            "rating": rating_registration,
+            "users_rated": users_rated_registration,
+            "geek_rating": geek_rating_registration,
+        })
+        results["sample_status"] = compute_sample_status(
+            results["year_published"], training_cutoff_year
+        )
+        results["training_cutoff_year"] = training_cutoff_year
+
         # Add timestamp of scoring
         results["score_ts"] = datetime.now(timezone.utc).isoformat()
 
@@ -730,6 +747,8 @@ async def predict_games_endpoint(request: PredictGamesRequest):
                             "game_id",
                             "name",
                             "year_published",
+                            "sample_status",
+                            "training_cutoff_year",
                             "predicted_hurdle_prob",
                             "predicted_complexity",
                             "predicted_rating",
@@ -1178,6 +1197,18 @@ async def simulate_games_endpoint(request: SimulateGamesRequest):
             geek_rating_pipeline=geek_rating_pipeline,
         )
 
+        # Label each row against the cutoff the loaded models were fitted through
+        training_cutoff_year = resolve_training_cutoff_year({
+            "hurdle": hurdle_reg,
+            "complexity": complexity_reg,
+            "rating": rating_reg,
+            "users_rated": users_rated_reg,
+            "geek_rating": geek_rating_reg,
+        })
+        sample_status = compute_sample_status(
+            df_pandas["year_published"], training_cutoff_year
+        )
+
         # Flatten simulation results into a DataFrame for upload/storage
         flat_rows = []
         for i, r in enumerate(sim_results):
@@ -1185,6 +1216,8 @@ async def simulate_games_endpoint(request: SimulateGamesRequest):
                 "game_id": r.game_id,
                 "name": r.game_name,
                 "year_published": df_pandas.iloc[i]["year_published"],
+                "sample_status": sample_status.iloc[i],
+                "training_cutoff_year": training_cutoff_year,
                 "predicted_hurdle_prob": float(predicted_hurdle_prob.iloc[i]),
                 "predicted_complexity": float(np.median(r.complexity_samples)),
                 "predicted_rating": float(np.median(r.rating_samples)),

--- a/services/scoring/main.py
+++ b/services/scoring/main.py
@@ -99,6 +99,7 @@ class PredictGamesRequest(BaseModel):
     game_ids: Optional[List[int]] = None
     use_change_detection: bool = False  # NEW: Enable incremental scoring
     max_games: Optional[int] = 50000    # NEW: Limit for change detection mode
+    min_users_rated: Optional[int] = None  # Restrict to rated games (backfill)
 
 
 class PredictGamesResponse(BaseModel):
@@ -133,6 +134,7 @@ class SimulateGamesRequest(BaseModel):
     upload_to_data_warehouse: bool = True
     use_change_detection: bool = False
     max_games: Optional[int] = 50000
+    min_users_rated: Optional[int] = None  # Restrict to rated games (backfill)
 
 
 class SimulateGamesResponse(BaseModel):
@@ -312,6 +314,7 @@ def load_games_for_main_scoring(
     rating_model_version: Optional[int] = None,
     users_rated_model_version: Optional[int] = None,
     geek_rating_model_version: Optional[int] = None,
+    min_users_rated: Optional[int] = None,
 ) -> pd.DataFrame:
     """
     Load games that need main predictions (hurdle, rating, users_rated, geek_rating).
@@ -325,6 +328,8 @@ def load_games_for_main_scoring(
         start_year: Start year for predictions (inclusive)
         end_year: End year for predictions (exclusive)
         max_games: Maximum number of games to load
+        min_users_rated: Restrict to games with at least this many ratings
+            (unset for scheduled runs; set for the rated-game backfill)
         hurdle_model_version: Target hurdle model version (rescore if different)
         complexity_model_version: Target complexity model version (rescore if different)
         rating_model_version: Target rating model version (rescore if different)
@@ -348,6 +353,7 @@ def load_games_for_main_scoring(
         rating_model_version=rating_model_version,
         users_rated_model_version=users_rated_model_version,
         geek_rating_model_version=geek_rating_model_version,
+        min_users_rated=min_users_rated,
     )
     return df.to_pandas()
 
@@ -586,6 +592,7 @@ async def predict_games_endpoint(request: PredictGamesRequest):
                 request.start_year or 2024,
                 request.end_year or 2029,
                 max_games=request.max_games or 50000,
+                min_users_rated=request.min_users_rated,
                 hurdle_model_version=hurdle_registration["version"],
                 complexity_model_version=complexity_registration["version"],
                 rating_model_version=rating_registration["version"],
@@ -1158,6 +1165,7 @@ async def simulate_games_endpoint(request: SimulateGamesRequest):
                 start_year=request.start_year,
                 end_year=request.end_year,
                 max_games=request.max_games,
+                min_users_rated=request.min_users_rated,
                 hurdle_model_version=hurdle_reg["version"],
                 complexity_model_version=complexity_reg["version"],
                 rating_model_version=rating_reg["version"],

--- a/services/scoring/sample_status.py
+++ b/services/scoring/sample_status.py
@@ -1,0 +1,66 @@
+"""Label predictions as fitted values or forecasts.
+
+The training cutoff is a property of the model, not the game, so it is read from
+the registration of the model actually loaded. Reading it from config.yaml would
+let the label drift from the deployed artifact the next time a model is refit,
+which is the whole thing this is meant to prevent.
+"""
+
+import logging
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_training_cutoff_year(registrations: Dict[str, Dict[str, Any]]) -> int:
+    """Return the year the loaded models were fitted through.
+
+    Models are refit through their test year, so `test_through` in the
+    registration is the training cutoff.
+
+    Args:
+        registrations: Registration dicts keyed by target (hurdle, rating, ...)
+
+    Returns:
+        The training cutoff year. If the models disagree, the minimum, so that
+        in_sample means "seen by every model".
+
+    Raises:
+        ValueError: If any registration has no test_through to read.
+    """
+    cutoffs = {}
+    for target, registration in registrations.items():
+        metadata = registration.get("original_experiment", {}).get("metadata", {})
+        cutoff = metadata.get("test_through")
+        if cutoff is None:
+            raise ValueError(
+                f"Registration for '{target}' has no test_through in "
+                f"original_experiment.metadata -- cannot determine the training "
+                f"cutoff, and guessing it would make sample_status meaningless"
+            )
+        cutoffs[target] = int(cutoff)
+
+    if len(set(cutoffs.values())) > 1:
+        logger.warning(
+            f"Models disagree on training cutoff: {cutoffs}. "
+            f"Using {min(cutoffs.values())} so in_sample means seen by every model."
+        )
+    return min(cutoffs.values())
+
+
+def compute_sample_status(
+    year_published: pd.Series, training_cutoff_year: int
+) -> pd.Series:
+    """Label each prediction as a fitted value or a forecast.
+
+    Binary: games without a year_published are never scored, so there is no
+    third case to represent.
+    """
+    return pd.Series(
+        np.where(year_published <= training_cutoff_year, "in_sample", "out_of_sample"),
+        index=year_published.index,
+        name="sample_status",
+    )

--- a/src/data/bigquery_uploader.py
+++ b/src/data/bigquery_uploader.py
@@ -98,6 +98,8 @@ class DataWarehousePredictionUploader:
                 - predicted_rating (optional)
                 - predicted_users_rated (optional)
                 - predicted_geek_rating (optional)
+                - sample_status (optional)
+                - training_cutoff_year (optional)
             job_id: Unique identifier for this prediction job
             model_versions: Optional dict with model version info, e.g.:
                 {"hurdle": "hurdle-v2025", "complexity": "complexity-v2025", ...}

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -357,6 +357,7 @@ class BGGDataLoader:
         users_rated_model_version: Optional[int] = None,
         geek_rating_model_version: Optional[int] = None,
         embeddings_table: Optional[str] = None,
+        min_users_rated: Optional[int] = None,
         timeout: int = 300,
     ) -> pl.DataFrame:
         """Load games needing re-scoring, joined with embeddings.
@@ -377,6 +378,9 @@ class BGGDataLoader:
             users_rated_model_version: Target users_rated model version
             geek_rating_model_version: Target geek_rating model version
             embeddings_table: Full BigQuery table path for embeddings
+            min_users_rated: Restrict to games with at least this many ratings.
+                Left unset for scheduled runs, which score upcoming games
+                regardless of ratings; set for the rated-game backfill.
             timeout: Timeout in seconds for BigQuery query execution
 
         Returns:
@@ -407,6 +411,10 @@ class BGGDataLoader:
         if version_checks:
             version_condition = "OR " + "\n          OR ".join(version_checks)
 
+        ratings_condition = ""
+        if min_users_rated is not None:
+            ratings_condition = f"AND gf.users_rated >= {int(min_users_rated)}"
+
         query = f"""
         SELECT f.*, e.embedding
         FROM `{features_table}` f
@@ -433,6 +441,7 @@ class BGGDataLoader:
             gf.year_published IS NOT NULL
             AND gf.year_published >= {start_year}
             AND gf.year_published < {end_year}
+            {ratings_condition}
             AND (
               lp.game_id IS NULL
               OR fh.last_updated > lp.score_ts

--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -192,6 +192,18 @@ resource "google_bigquery_table" "ml_predictions_landing" {
       mode = "NULLABLE"
     },
     {
+      name        = "sample_status"
+      type        = "STRING"
+      mode        = "NULLABLE"
+      description = "in_sample if the loaded models were fitted on this game's year, else out_of_sample"
+    },
+    {
+      name        = "training_cutoff_year"
+      type        = "INTEGER"
+      mode        = "NULLABLE"
+      description = "Year the scoring models were fitted through (test_through from the model registration)"
+    },
+    {
       name = "score_ts"
       type = "TIMESTAMP"
       mode = "REQUIRED"

--- a/tests/test_loader_ratings_filter.py
+++ b/tests/test_loader_ratings_filter.py
@@ -1,0 +1,70 @@
+"""Tests for the min_users_rated predicate in change-detection loading.
+
+Scheduled runs score upcoming games regardless of ratings; only the backfill
+restricts to rated games, so the predicate must be absent unless asked for.
+"""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from src.data.loader import BGGDataLoader
+
+
+def _loader_capturing_sql():
+    """Return (loader, get_sql) where get_sql yields the query that was issued."""
+    config = MagicMock()
+    config.project_id = "proj"
+    config.dataset = "analytics"
+    config.table = "games_features"
+
+    query_job = MagicMock()
+    query_job.to_dataframe.return_value = pd.DataFrame()  # short-circuits the load
+    config.get_client.return_value.query.return_value = query_job
+
+    loader = BGGDataLoader(config)
+    return loader, lambda: loader.client.query.call_args[0][0]
+
+
+def _load(loader, **kwargs):
+    return loader.load_changed_games_with_embeddings(
+        start_year=1900,
+        end_year=2030,
+        ml_project_id="ml-proj",
+        **kwargs,
+    )
+
+
+def test_no_ratings_predicate_by_default():
+    loader, get_sql = _loader_capturing_sql()
+
+    _load(loader)
+
+    assert "users_rated >=" not in get_sql()
+
+
+def test_ratings_predicate_applied_when_requested():
+    loader, get_sql = _loader_capturing_sql()
+
+    _load(loader, min_users_rated=25)
+
+    assert "gf.users_rated >= 25" in get_sql()
+
+
+def test_ratings_predicate_does_not_replace_year_filter():
+    loader, get_sql = _loader_capturing_sql()
+
+    _load(loader, min_users_rated=25)
+
+    sql = get_sql()
+    assert "gf.year_published >= 1900" in sql
+    assert "gf.year_published < 2030" in sql
+
+
+def test_ratings_predicate_is_not_string_interpolated_raw():
+    # Guards against a non-integer reaching the SQL text
+    loader, get_sql = _loader_capturing_sql()
+
+    _load(loader, min_users_rated="25")
+
+    assert "gf.users_rated >= 25" in get_sql()

--- a/tests/test_scoring_sample_status.py
+++ b/tests/test_scoring_sample_status.py
@@ -1,0 +1,70 @@
+"""Tests for sample_status / training_cutoff_year in services.scoring.main."""
+
+import pandas as pd
+import pytest
+
+from services.scoring.sample_status import (
+    compute_sample_status,
+    resolve_training_cutoff_year,
+)
+
+
+def _registration(test_through):
+    return {"original_experiment": {"metadata": {"test_through": test_through}}}
+
+
+def _all_targets(test_through):
+    return {
+        target: _registration(test_through)
+        for target in ("hurdle", "complexity", "rating", "users_rated", "geek_rating")
+    }
+
+
+def test_cutoff_read_from_registration_when_models_agree():
+    assert resolve_training_cutoff_year(_all_targets(2024)) == 2024
+
+
+def test_cutoff_takes_minimum_when_models_disagree():
+    # in_sample must mean "seen by every model", so the narrowest cutoff wins
+    registrations = _all_targets(2024)
+    registrations["geek_rating"] = _registration(2023)
+
+    assert resolve_training_cutoff_year(registrations) == 2023
+
+
+def test_cutoff_raises_rather_than_guessing_when_absent():
+    # Falling back to config.yaml would let the flag drift from the loaded model
+    registrations = _all_targets(2024)
+    registrations["rating"] = {"original_experiment": {"metadata": {}}}
+
+    with pytest.raises(ValueError, match="test_through"):
+        resolve_training_cutoff_year(registrations)
+
+
+def test_cutoff_raises_when_registration_has_no_experiment_metadata():
+    with pytest.raises(ValueError, match="test_through"):
+        resolve_training_cutoff_year({"hurdle": {}})
+
+
+def test_sample_status_splits_at_the_cutoff_year():
+    years = pd.Series([2022, 2023, 2024, 2025, 2026])
+
+    status = compute_sample_status(years, training_cutoff_year=2024)
+
+    assert list(status) == [
+        "in_sample",
+        "in_sample",
+        "in_sample",  # the cutoff year itself was fitted on
+        "out_of_sample",
+        "out_of_sample",
+    ]
+
+
+def test_sample_status_preserves_index_for_row_alignment():
+    years = pd.Series([2020, 2030], index=[7, 11])
+
+    status = compute_sample_status(years, training_cutoff_year=2024)
+
+    assert list(status.index) == [7, 11]
+    assert status.loc[7] == "in_sample"
+    assert status.loc[11] == "out_of_sample"


### PR DESCRIPTION
Every prediction row now says whether it is a fitted value or a forecast.

Implements [the spec](docs/specs/2026-07-30-universal-scoring-and-sample-status-design.md) and [plan](docs/plans/2026-07-30-universal-scoring-and-sample-status.md), both corrected in this branch — see below.

## What changed

- **`services/scoring/sample_status.py`** (new) — resolves the training cutoff from the registration of the model actually loaded, and labels each row.
- **`services/scoring/main.py`** — emits both fields from `simulate_games` (the prod path) and `predict_games`, so the two cannot drift apart.
- **`src/data/loader.py`** — optional `min_users_rated` predicate on the change-detection query, for the backfill.
- **`terraform/bigquery.tf`** — `sample_status` (STRING) and `training_cutoff_year` (INTEGER) on `ml_predictions_landing`.

## Two corrections to the original spec

**The cutoff is 2024, not 2025.** Verified against the deployed registrations in GCS: all five models report `train_through: 2022, tune_through: 2023, test_through: 2024`. Models are refit through their test year, so `test_through` is the cutoff. `config.yaml`'s `finalize_through: 2025` is read by no game-model code — the only `.py` references are in `services/collections/`, a separate system. **2025 games are `out_of_sample`.**

**The coverage gap is ~30k, not ~110k.** Upcoming games are already scored; the gap is the rated games. At a measured ~77ms/game that is ~40 minutes in the existing batch loop, so batch size, run mode and parallelism are all non-questions.

## Design notes

- The cutoff resolver **raises rather than falling back to config** — a fallback would let the label drift from the deployed artifact on the next refit, which is the whole point of the field.
- If the five models ever disagree it takes the minimum, so `in_sample` means "seen by every model".
- `sample_status` is binary but STRING-typed: games without a `year_published` are never scored, so there is no third case, and a string can gain values later without a schema change.

## Testing

10 new tests, all passing. The suite has 17 pre-existing failures in `test_transformers.py` plus two modules that fail to import (`test_train.py`, `test_geek_rating.py`) — identical before and after this branch, confirmed by stashing.

## Not in this PR

- The `bgg_predictions.sqlx` change and its **full refresh** (schema change on an incremental table) — separate repo.
- Running the backfill.
- The `is_new_1d`/`is_new_7d` question: ~30k games would share a `first_prediction_ts`. The predictions report already scopes to upcoming so is likely unaffected; the collection report computes its own flag. Unverified for bgg-viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)