### PR TITLE
fix(docker): copy README.md and sample_status.py into the scoring image

### DIFF
--- a/docker/scoring.Dockerfile
+++ b/docker/scoring.Dockerfile
@@ -20,12 +20,16 @@ RUN apt-get update --allow-releaseinfo-change && \
 RUN pip install uv
 
 # Copy required files
+# README.md is referenced by pyproject.toml's `readme` field; uv sync reads the
+# metadata and fails without it.
 COPY pyproject.toml .
 COPY uv.lock .
+COPY README.md .
 COPY services/scoring/main.py .
 COPY services/scoring/cloud_experiment_tracker.py .
 COPY services/scoring/registered_model.py .
 COPY services/scoring/auth.py .
+COPY services/scoring/sample_status.py .
 COPY src/ /app/src/
 
 # Copy config files


### PR DESCRIPTION
Unblocks the scoring image build, which has been failing since #62 triggered the first rebuild in three months.

## Two lines, both additive

```
+COPY README.md .
+COPY services/scoring/sample_status.py .
```

## Why the README is suddenly required

`readme = "README.md"` in `pyproject.toml` is unchanged and has always been there. What changed since the last successful build (2026-04-29) is a new `[build-system]` section:

```toml
[build-system]
requires = ["hatchling"]
build-backend = "hatchling.build"
```

Before that, uv treated the project as virtual — it installed dependencies and never built the project itself, so nothing ever parsed `readme`. Now `uv sync` builds and installs the local package, hatchling validates the metadata, and the missing file raises `OSError: Readme file does not exist`.

The alternative fix is `uv sync --no-install-project`, since the image doesn't use the installed package — it copies `main.py` to `/app` and `src/` to `/app/src` and puts those on `sys.path` itself. That's a larger change to what's actually installed, so not bundled here.

## Why sample_status.py

#62 added it; the Dockerfile copies `services/scoring/` files one at a time, so it would have been absent from the image and `main.py` would have failed at import.

Kept the explicit list rather than globbing — it is an allowlist. `services/scoring/*.py` would also pull in `register_model.py`, `score.py`, `verify_models.py` and `__init__.py`, none of which belong in the serving image.

## Deploy note

Traffic on `bgg-model-scoring` is set to follow the latest revision, so merging this takes the new image live as soon as it is ready. Current revision is `bgg-model-scoring-00019-pqf` (2026-04-29); rollback is:

```
gcloud run services update-traffic bgg-model-scoring \
  --region us-central1 --to-revisions=bgg-model-scoring-00019-pqf=100
```

Verified beforehand that the rebuild cannot move predictions: every numerical dependency is identical between the April lock and main (scikit-learn 1.7.0, numpy 2.2.6, scipy 1.16.0, pandas 2.3.0, joblib 1.5.1), and `simulation.py`, the preprocessing code and `explain.py` are unchanged. Predictions will still be diffed against existing rows after deploy, before any backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)