### PR TITLE
feat(ci): min_users_rated and max_batches inputs for the rated-game backfill

### DIFF
--- a/.github/workflows/run-scoring-service.yml
+++ b/.github/workflows/run-scoring-service.yml
@@ -23,6 +23,14 @@ on:
         description: 'Maximum games per batch'
         required: false
         default: '50000'
+      min_users_rated:
+        description: 'Only score games with at least this many ratings (blank = no filter)'
+        required: false
+        default: ''
+      max_batches:
+        description: 'Safety limit on batch count'
+        required: false
+        default: '10'
 
 env:
   GCP_PROJECT_ID: bgg-predictive-models
@@ -96,10 +104,19 @@ jobs:
         END_YEAR="${{ github.event.inputs.end_year || '2030' }}"
         N_SAMPLES="${{ github.event.inputs.n_samples || '1000' }}"
         MAX_GAMES="${{ github.event.inputs.max_games || '50000' }}"
+        MIN_USERS_RATED="${{ github.event.inputs.min_users_rated || '' }}"
+
+        # Omit the key entirely when unset, so scheduled runs keep scoring
+        # upcoming games regardless of ratings
+        if [ -n "$MIN_USERS_RATED" ]; then
+          MIN_RATED_FIELD="\"min_users_rated\": $MIN_USERS_RATED,"
+        else
+          MIN_RATED_FIELD=""
+        fi
 
         TOTAL_GAMES=0
         BATCH_COUNT=0
-        MAX_BATCHES=10  # Safety limit
+        MAX_BATCHES="${{ github.event.inputs.max_batches || '10' }}"
 
         while [ $BATCH_COUNT -lt $MAX_BATCHES ]; do
           BATCH_COUNT=$((BATCH_COUNT + 1))
@@ -119,6 +136,7 @@ jobs:
               \"n_samples\": $N_SAMPLES,
               \"use_change_detection\": true,
               \"max_games\": $MAX_GAMES,
+              $MIN_RATED_FIELD
               \"upload_to_data_warehouse\": true
             }" \
             -w "\n%{http_code}" \
@@ -159,6 +177,7 @@ jobs:
         echo "- **Environment**: ${{ steps.env.outputs.env_name }}" >> $GITHUB_STEP_SUMMARY
         echo "- **Models**: ${{ steps.models.outputs.hurdle }}, ${{ steps.models.outputs.complexity }}, ${{ steps.models.outputs.rating }}, ${{ steps.models.outputs.users_rated }}, ${{ steps.models.outputs.geek_rating }}" >> $GITHUB_STEP_SUMMARY
         echo "- **Year Range**: ${{ github.event.inputs.start_year || '2025' }}-${{ github.event.inputs.end_year || '2030' }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Min Users Rated**: ${{ github.event.inputs.min_users_rated || 'none (all games in range)' }}" >> $GITHUB_STEP_SUMMARY
         echo "- **N Samples**: ${{ github.event.inputs.n_samples || '1000' }}" >> $GITHUB_STEP_SUMMARY
         echo "- **Batches Completed**: ${{ steps.simulate.outputs.batch_count }}" >> $GITHUB_STEP_SUMMARY
         echo "- **Total Games Scored**: ${{ steps.simulate.outputs.total_games }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Makes `Run Scoring Service` able to express the rated-game backfill.

## Why the workflow couldn't do it

- **No ratings filter.** A wide `start_year` would score every game with an embedding (~128k), not the ~30k rated ones.
- **Batch size.** `MAX_BATCHES=10` with `max_games=50000` would attempt 30k games in one request. At the measured ~77ms/game that is ~38 minutes, past the 1800s Cloud Run timeout.

## Changes

- `min_users_rated` input, passed through to the scoring service (added in #62)
- `max_batches` input, previously a hardcoded `10`
- Both surfaced in the job summary

The `min_users_rated` key is **omitted from the payload entirely** when blank, so scheduled `dataform_complexity_ready` runs keep scoring upcoming games regardless of ratings. Verified the payload is valid JSON in both modes.

## Intended backfill invocation

```
start_year=1900  min_users_rated=25  max_games=2500  max_batches=20
```

~12 batches of ~190s each.

## Prerequisites, all met

- #62 merged — service accepts `min_users_rated` and emits the new fields
- #63 merged — image builds; revision `bgg-model-scoring-00020-8dn` live
- Verified on the live revision: predictions bit-identical to the April image across 100 games and 5 columns (0 differences in 500 values), `training_cutoff_year` resolving to 2024 from the registrations, `sample_status` splitting exactly at 2024/2025

🤖 Generated with [Claude Code](https://claude.com/claude-code)